### PR TITLE
Setting order sNet to hide the VAT

### DIFF
--- a/Controllers/Frontend/Mollie.php
+++ b/Controllers/Frontend/Mollie.php
@@ -1135,9 +1135,13 @@ class Shopware_Controllers_Frontend_Mollie extends AbstractPaymentController
             if (is_array($variables)) {
                 try {
                     $sOrder->sUserData = $variables;
+
+                    if (isset($variables['additional']['charge_vat']) && $variables['additional']['charge_vat'] === false) {
+                        $sOrder->sNet = true;
+                    }
+
                     $sOrder->sendMail($variables);
-                }
-                catch (\Exception $ex) {
+                } catch (\Exception $ex) {
                     Logger::log('error', $ex->getMessage(), $ex);
                 }
             }


### PR DESCRIPTION
When ordering from a foreign country, VAT may not be applied.
But in the order confirmation e-mail it will still be visible. By setting sNet on the Shopware Order class the VAT will not be visible in the confirmation e-mail. 