### PR TITLE
Parse order id instead of model to the getMollieOrderId() method

### DIFF
--- a/Controllers/Backend/MollieOrders.php
+++ b/Controllers/Backend/MollieOrders.php
@@ -46,7 +46,7 @@ class Shopware_Controllers_Backend_MollieOrders extends Shopware_Controllers_Bac
             if (empty($order))
                 $this->returnError('Order not found');
 
-            $mollieId = $this->orderService->getMollieOrderId($order);
+            $mollieId = $this->orderService->getMollieOrderId($order->getId());
 
             if (empty($mollieId))
                 $this->returnError('Order is paid as a single payment (not an order) at Mollie');


### PR DESCRIPTION
Currently, orders cannot be shipped at Molly and you will always get the error message 'Order is paid as a single payment (not an order) at Mollie'. This will fix that.