### PR TITLE
MOL-4: fix checkout with NON 3D-SECURE credit cards

### DIFF
--- a/Controllers/Frontend/Mollie.php
+++ b/Controllers/Frontend/Mollie.php
@@ -7,6 +7,7 @@ use MollieShopware\Components\Logger;
 use MollieShopware\Components\Notifier;
 use MollieShopware\Components\Constants\PaymentStatus;
 use MollieShopware\Components\Base\AbstractPaymentController;
+use MollieShopware\Components\Services\PaymentService;
 use MollieShopware\Models\Transaction;
 use MollieShopware\Models\TransactionRepository;
 use Shopware\Models\Order\Order;
@@ -145,7 +146,20 @@ class Shopware_Controllers_Frontend_Mollie extends AbstractPaymentController
             $this->getPaymentShortName(),
             $transaction
         );
-
+        
+        if ($checkoutUrl === PaymentService::CHECKOUT_URL_CC_NON3D_SECURE) {
+            # just finish our payment by redirecting
+            # to our return, such as if the user would have really
+            # visited the mollie payment form.
+            return $this->redirect(
+                [
+                    'controller' => 'Mollie',
+                    'action' => 'return',
+                    'transactionNumber' => $transaction->getId(),
+                ]
+            );
+        }
+        
         if (is_array($checkoutUrl)) {
             return $this->redirectBack($checkoutUrl['error'], $checkoutUrl['message']);
         }


### PR DESCRIPTION
if you use a non-3d secure credit card
the checkoutURL is not existing,
thus there will be an error when finishing the order

so i've added a check if its a valid "paid" credit card payment without a checkout URL...in that case its OK because it (should be) a non-3d secure card

i just redirect to the return action just as if the visitor is returning from the external mollie payment form

the order of this non-3d payment was then "paid" and completed in the shopware backend