### PR TITLE
NTR: Fix broken CRUD uninstaller

### DIFF
--- a/Components/Attributes.php
+++ b/Components/Attributes.php
@@ -70,7 +70,11 @@ class Attributes
      */
     public function remove($columnSpecs)
     {
-        foreach ($columnSpecs as $table => $columnSpec) {
+        foreach ($columnSpecs as $spec) {
+
+            $table = $spec[0];
+            $columnSpec = $spec[1];
+
             if ($this->columnExists($table, $columnSpec)) {
                 call_user_func_array([ $this->crudService, 'delete' ], $columnSpec);
             }


### PR DESCRIPTION
somehow the structure of the uninstaller for the CRUD handling of the entities was different in my case?

it was no key/value array

can you please verify this and only merge it if correct?