### PR TITLE
MOL-15: remove duplicate advanced promotion discount items

### DIFF
--- a/Components/Helpers/MollieLineItemCleaner.php
+++ b/Components/Helpers/MollieLineItemCleaner.php
@@ -1,0 +1,47 @@
+<?php
+
+
+namespace MollieShopware\Components\Helpers;
+
+
+class MollieLineItemCleaner
+{
+
+    /**
+     * Sometimes the advanced promotion suite leads to
+     * duplicate discount entries? To avoid that problem
+     * this function can easily remove duplicate entries.
+     * This will lead to a correct mollie api request and avoid the
+     * problem that the amount of line items does not match the
+     * total sum of the order.
+     * 
+     * @param array $orderlines
+     * @return array
+     */
+    public function removeDuplicateDiscounts(array $orderlines)
+    {
+        $newLines = array();
+        $cachedDiscountIDs = array();
+        
+        /** @var array $line */
+        foreach ($orderlines as $line) {
+
+            if ($line['type'] !== 'discount') {
+                $newLines[] = $line;
+                continue;
+            }
+
+            # only add our discounts once.
+            # the identifier is the name + price.
+            $id = $line['name'] . $line['unitPrice']['value'];
+
+            if (!in_array($id, $cachedDiscountIDs)) {
+                $newLines[] = $line;
+                $cachedDiscountIDs[] = $id;
+            }
+        }
+        
+        return $newLines;
+    }
+
+}

--- a/Components/Services/PaymentService.php
+++ b/Components/Services/PaymentService.php
@@ -6,6 +6,7 @@ use Mollie\Api\Exceptions\ApiException;
 use Mollie\Api\Resources\Payment;
 use MollieShopware\Components\Constants\PaymentMethod;
 use MollieShopware\Components\Constants\PaymentStatus;
+use MollieShopware\Components\Helpers\MollieLineItemCleaner;
 use MollieShopware\Models\Transaction;
 use MollieShopware\Models\TransactionRepository;
 use Shopware\Models\Order\Status;
@@ -526,7 +527,15 @@ class PaymentService
                 'metadata' => json_encode(['transaction_item_id' => $item->getId()]),
             ];
         }
-
+        
+        
+        $cleaner = new MollieLineItemCleaner();
+        
+        # sometimes the advanced promotion suite has duplicate discounts in there.
+        # so we just remove these, otherwise we would get the error
+        # "amount of line items does not match provided total sum" of mollie
+        $orderlines = $cleaner->removeDuplicateDiscounts($orderlines);
+        
         return $orderlines;
     }
 


### PR DESCRIPTION
sometimes the advanced promotion suite shows duplicate discount line items
and mollie api responds with "total value does not equal to sum of line item values".

so i've added a simple cleaner that removes duplicate discount items