### PR TITLE
MOL-14: fix wrong mollie config for klarna shipping in subshop

### DIFF
--- a/Components/Config.php
+++ b/Components/Config.php
@@ -7,6 +7,7 @@ use MollieShopware\Components\Services\ShopService;
 use Shopware\Components\Plugin\ConfigReader;
 use Shopware\Models\Order\Status;
 use Shopware\Models\Shop\Repository;
+use Shopware\Models\Shop\Shop;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
 class Config
@@ -96,7 +97,7 @@ class Config
 
         // get default shop
         /** @var Repository $shopRepository */
-        $shopRepository = Shopware()->Models()->getRepository('Shopware\\Models\\Shop\\Shop');
+        $shopRepository = Shopware()->Models()->getRepository(Shop::class);
         $mainShop = $shopRepository->getActiveDefault();
 
         if ($mainShop === null) {

--- a/Components/Config.php
+++ b/Components/Config.php
@@ -5,12 +5,15 @@ namespace MollieShopware\Components;
 use Exception;
 use MollieShopware\Components\Services\ShopService;
 use Shopware\Components\Plugin\ConfigReader;
+use Shopware\Models\Order\Status;
+use Shopware\Models\Shop\Repository;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
 class Config
 {
     const TRANSACTION_NUMBER_TYPE_MOLLIE = 'mollie';
     const TRANSACTION_NUMBER_TYPE_PAYMENT_METHOD = 'payment_method';
+    const INHERITED_CONFIG_VALUE = 'inherited';
 
     /** @var ConfigReader */
     private $configReader;
@@ -67,7 +70,9 @@ class Config
             // get config for shop or for main if shopid is null
             $parts = explode('\\', __NAMESPACE__);
             $name = array_shift($parts);
-            $this->data = $this->configReader->getByPluginName($name, $shop);
+            $config = $this->configReader->getByPluginName($name, $shop);
+            $config = $this->addInheritedConfig($config, $name);
+            $this->data = $config;
         }
 
         if (!empty($key)) {
@@ -75,6 +80,39 @@ class Config
         }
 
         return $this->data;
+    }
+
+    /**
+     * @param array $config
+     * @param string $name
+     * @return array
+     */
+    private function addInheritedConfig(array $config, $name)
+    {
+        // check if inherited or null fields are in config to get from default shop
+        if (!in_array(self::INHERITED_CONFIG_VALUE, $config) && !in_array(null, $config)) {
+            return $config;
+        }
+
+        // get default shop
+        /** @var Repository $shopRepository */
+        $shopRepository = Shopware()->Models()->getRepository('Shopware\\Models\\Shop\\Shop');
+        $mainShop = $shopRepository->getActiveDefault();
+
+        if ($mainShop === null) {
+            return $config;
+        }
+
+        $inheritedConfig = $this->configReader->getByPluginName($name, $mainShop);
+
+        // replace inherited or null fields in config
+        foreach ($config as $key => $value) {
+            if ($value === self::INHERITED_CONFIG_VALUE || $value === null) {
+                $config[$key] = $inheritedConfig[$key];
+            }
+        }
+
+        return $config;
     }
 
     /**
@@ -160,7 +198,7 @@ class Config
      */
     public function getAuthorizedPaymentStatusId()
     {
-        $statusModel = new \Shopware\Models\Order\Status();
+        $statusModel = new Status();
         $paymentStatus = null;
         $configuredStatus = $this->get('payment_authorized_status', 'ordered');
 
@@ -200,7 +238,7 @@ class Config
      */
     public function getKlarnaShipOnStatus()
     {
-        return (int) $this->get('klarna_ship_on_status', \Shopware\Models\Order\Status::ORDER_STATE_COMPLETELY_DELIVERED);
+        return (int) $this->get('klarna_ship_on_status', Status::ORDER_STATE_COMPLETELY_DELIVERED);
     }
 
     /**

--- a/Components/Helpers/MollieShopSwitcher.php
+++ b/Components/Helpers/MollieShopSwitcher.php
@@ -49,7 +49,7 @@ class MollieShopSwitcher
     public function getMollieApi($shopId)
     {
         /** @var MollieApiFactory $apiFactory */
-        $apiFactory = Shopware()->Container()->get('mollie_shopware.api_factory');
+        $apiFactory = $this->container->get('mollie_shopware.api_factory');
 
         return $apiFactory->create($shopId);
     }

--- a/Components/Helpers/MollieShopSwitcher.php
+++ b/Components/Helpers/MollieShopSwitcher.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace MollieShopware\Components\Helpers;
+
+use MollieShopware\Components\Config;
+use MollieShopware\Components\MollieApiFactory;
+use Psr\Container\ContainerInterface;
+
+class MollieShopSwitcher
+{
+
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+
+    /**
+     * MollieShopSwitcher constructor.
+     *
+     * @param ContainerInterface $container
+     */
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    
+    /**
+     * @param $shopId
+     * @return Config
+     */
+    public function getConfig($shopId)
+    {
+        /** @var Config $config */
+        $config = $this->container->get('mollie_shopware.config');
+
+        $config->setShop($shopId);
+
+        return $config;
+    }
+
+    /**
+     * @param $shopId
+     * @return \Mollie\Api\MollieApiClient
+     * @throws \Mollie\Api\Exceptions\ApiException
+     * @throws \Mollie\Api\Exceptions\IncompatiblePlatform
+     */
+    public function getMollieApi($shopId)
+    {
+        /** @var MollieApiFactory $apiFactory */
+        $apiFactory = Shopware()->Container()->get('mollie_shopware.api_factory');
+
+        return $apiFactory->create($shopId);
+    }
+
+}

--- a/Components/MollieApiFactory.php
+++ b/Components/MollieApiFactory.php
@@ -61,10 +61,11 @@ class MollieApiFactory
 
         // set the configuration for the shop
         $this->config->setShop($shopId);
-
+        
+        $key = $this->config->apiKey();
         // set the api key based on the configuration
-        $this->apiClient->setApiKey($this->config->apiKey());
-
+        $this->apiClient->setApiKey($key);
+            
         return $this->apiClient;
     }
 

--- a/Components/Services/PaymentService.php
+++ b/Components/Services/PaymentService.php
@@ -3,6 +3,7 @@
 namespace MollieShopware\Components\Services;
 
 use Mollie\Api\Exceptions\ApiException;
+use Mollie\Api\MollieApiClient;
 use Mollie\Api\Resources\Payment;
 use MollieShopware\Components\Constants\PaymentMethod;
 use MollieShopware\Components\Constants\PaymentStatus;
@@ -56,6 +57,30 @@ class PaymentService
         $this->customEnvironmentVariables = $customEnvironmentVariables;
     }
 
+    /**
+     * This function helps to use a different api client 
+     * for this payment methods service.
+     * One day there should be a refactoring to do this in the constructor.
+     * 
+     * @param MollieApiClient $client
+     */
+    public function switchApiClient(MollieApiClient $client)
+    {
+        $this->apiClient = $client;
+    }
+
+    /**
+     * This function helps to use a different config
+     * for this payment methods service.
+     * One day there should be a refactoring to do this in the constructor.
+     * 
+     * @param \MollieShopware\Components\Config $config
+     */
+    public function switchConfig(\MollieShopware\Components\Config $config)
+    {
+        $this->config = $config;
+    }
+    
     /**
      * Create the transaction in the TransactionRepository.
      *

--- a/Controllers/Backend/MollieOrders.php
+++ b/Controllers/Backend/MollieOrders.php
@@ -2,6 +2,7 @@
 
 use Mollie\Api\Resources\Order;
 use Mollie\Api\Resources\OrderLine;
+use MollieShopware\Components\Helpers\MollieShopSwitcher;
 use Shopware\Models\Order\Detail;
 use Shopware\Models\Order\Status;
 
@@ -33,10 +34,7 @@ class Shopware_Controllers_Backend_MollieOrders extends Shopware_Controllers_Bac
 
             /** @var \MollieShopware\Components\Config $config */
             $this->config = $this->container->get('mollie_shopware.config');
-
-            /** @var \Mollie\Api\MollieApiClient $apiClient */
-            $this->apiClient = $this->container->get('mollie_shopware.api');
-
+            
             /** @var \MollieShopware\Components\Services\OrderService $orderService */
             $this->orderService = $this->container->get('mollie_shopware.order_service');
 
@@ -50,7 +48,14 @@ class Shopware_Controllers_Backend_MollieOrders extends Shopware_Controllers_Bac
 
             if (empty($order))
                 $this->returnError('Order not found');
+            
+            
+            # switch to the config and api key of the shop from the order
+            $shopSwitcher = new MollieShopSwitcher($this->container);
+            $this->config = $shopSwitcher->getConfig($order->getShop()->getId());
+            $this->apiClient = $shopSwitcher->getMollieApi($order->getShop()->getId());
 
+            
             $mollieId = $this->orderService->getMollieOrderId($order);
 
             if (empty($mollieId))
@@ -106,10 +111,7 @@ class Shopware_Controllers_Backend_MollieOrders extends Shopware_Controllers_Bac
 
             /** @var \MollieShopware\Components\Config $config */
             $this->config = $this->container->get('mollie_shopware.config');
-
-            /** @var \Mollie\Api\MollieApiClient $apiClient */
-            $this->apiClient = $this->container->get('mollie_shopware.api');
-
+            
             /** @var \MollieShopware\Components\Services\OrderService $orderService */
             $this->orderService = $this->container->get('mollie_shopware.order_service');
 
@@ -121,6 +123,13 @@ class Shopware_Controllers_Backend_MollieOrders extends Shopware_Controllers_Bac
             if (empty($order))
                 $this->returnError('Order not found');
 
+
+            # switch to the config and api key of the shop from the order
+            $shopSwitcher = new MollieShopSwitcher($this->container);
+            $this->config = $shopSwitcher->getConfig($order->getShop()->getId());
+            $this->apiClient = $shopSwitcher->getMollieApi($order->getShop()->getId());
+            
+            
             /** @var Order $mollieOrder */
             try {
                 $mollieOrder = $this->apiClient->orders->get(
@@ -169,10 +178,7 @@ class Shopware_Controllers_Backend_MollieOrders extends Shopware_Controllers_Bac
 
             /** @var \MollieShopware\Components\Config $config */
             $this->config = $this->container->get('mollie_shopware.config');
-
-            /** @var \Mollie\Api\MollieApiClient $apiClient */
-            $this->apiClient = $this->container->get('mollie_shopware.api');
-
+            
             /** @var \MollieShopware\Components\Services\OrderService $orderService */
             $this->orderService = $this->container->get('mollie_shopware.order_service');
 
@@ -189,6 +195,11 @@ class Shopware_Controllers_Backend_MollieOrders extends Shopware_Controllers_Bac
             if (empty($order))
                 $this->returnError('Order not found');
 
+            # switch to the config and api key of the shop from the order
+            $shopSwitcher = new MollieShopSwitcher($this->container);
+            $this->config = $shopSwitcher->getConfig($order->getShop()->getId());
+            $this->apiClient = $shopSwitcher->getMollieApi($order->getShop()->getId());
+            
             /** @var Order $mollieOrder */
             try {
                 $mollieOrder = $this->apiClient->orders->get(
@@ -248,12 +259,11 @@ class Shopware_Controllers_Backend_MollieOrders extends Shopware_Controllers_Bac
                 $request->getParam('orderId')
             );
 
-            if (
-                $order !== null
-                && (string) $this->orderService->getMollieOrderId($order) !== ''
-            ) {
+            if ($order !== null && (string) $this->orderService->getMollieOrderId($order) !== '') 
+            {
                 $shippable = true;
             }
+            
         } catch (Exception $e) {
             //
         }

--- a/Resources/config.xml
+++ b/Resources/config.xml
@@ -17,6 +17,12 @@
             <value>yes</value>
             <store>
                 <option>
+                    <value>inherited</value>
+                    <label lang="de">Vererbt</label>
+                    <label lang="en">Inherited</label>
+                    <label lang="nl">Geërfd</label>
+                </option>
+                <option>
                     <value>yes</value>
                     <label lang="de">Ja</label>
                     <label lang="en">Yes</label>
@@ -38,6 +44,12 @@
             <label lang="nl">Stuur restitutiestatus mail</label>
             <value>yes</value>
             <store>
+                <option>
+                    <value>inherited</value>
+                    <label lang="de">Vererbt</label>
+                    <label lang="en">Inherited</label>
+                    <label lang="nl">Geërfd</label>
+                </option>
                 <option>
                     <value>yes</value>
                     <label lang="de">Ja</label>
@@ -61,6 +73,12 @@
             <value>yes</value>
             <store>
                 <option>
+                    <value>inherited</value>
+                    <label lang="de">Vererbt</label>
+                    <label lang="en">Inherited</label>
+                    <label lang="nl">Geërfd</label>
+                </option>
+                <option>
                     <value>yes</value>
                     <label lang="de">Ja</label>
                     <label lang="en">Yes</label>
@@ -83,6 +101,12 @@
             <value>yes</value>
             <store>
                 <option>
+                    <value>inherited</value>
+                    <label lang="de">Vererbt</label>
+                    <label lang="en">Inherited</label>
+                    <label lang="nl">Geërfd</label>
+                </option>
+                <option>
                     <value>yes</value>
                     <label lang="de">Ja</label>
                     <label lang="en">Yes</label>
@@ -104,6 +128,12 @@
             <label lang="nl">Status voor geautoriseerde betalingen (b.v. Klarna Pay Later)</label>
             <value>ordered</value>
             <store>
+                <option>
+                    <value>inherited</value>
+                    <label lang="de">Vererbt</label>
+                    <label lang="en">Inherited</label>
+                    <label lang="nl">Geërfd</label>
+                </option>
                 <option>
                     <value>ordered</value>
                     <label lang="de">Die Zahlung wurde angewiesen (not available in Shopware 5.3)</label>
@@ -149,6 +179,12 @@
             <value>mollie</value>
             <store>
                 <option>
+                    <value>inherited</value>
+                    <label lang="de">Vererbt</label>
+                    <label lang="en">Inherited</label>
+                    <label lang="nl">Geërfd</label>
+                </option>
+                <option>
                     <value>mollie</value>
                     <label lang="de">Mollie</label>
                     <label lang="en">Mollie</label>
@@ -170,6 +206,12 @@
             <label lang="nl">Order statussen vanuit Mollie overnemen</label>
             <value>no</value>
             <store>
+                <option>
+                    <value>inherited</value>
+                    <label lang="de">Vererbt</label>
+                    <label lang="en">Inherited</label>
+                    <label lang="nl">Geërfd</label>
+                </option>
                 <option>
                     <value>yes</value>
                     <label lang="de">Ja</label>
@@ -196,6 +238,12 @@
             <description lang="nl">Wanneer een bestelling wordt hersteld, automatisch de oude (mislukte) bestelling annuleren.</description>
             <store>
                 <option>
+                    <value>inherited</value>
+                    <label lang="de">Vererbt</label>
+                    <label lang="en">Inherited</label>
+                    <label lang="nl">Geërfd</label>
+                </option>
+                <option>
                     <value>yes</value>
                     <label lang="de">Ja</label>
                     <label lang="en">Yes</label>
@@ -217,6 +265,12 @@
             <label lang="nl">Besteltotaal en verzending leegmaken bij geannuleerde bestelling</label>
             <value>no</value>
             <store>
+                <option>
+                    <value>inherited</value>
+                    <label lang="de">Vererbt</label>
+                    <label lang="en">Inherited</label>
+                    <label lang="nl">Geërfd</label>
+                </option>
                 <option>
                     <value>yes</value>
                     <label lang="de">Ja</label>
@@ -242,6 +296,12 @@
             <description lang="en">By creating an order before finishing the payment, the order number (in stead of a temporary number) can be given to the payment.</description>
             <description lang="nl">Door de order te maken voor het afronden van de betaling, kan het order nummer (in plaats van een tijdelijk nummer) worden meegegeven aan de betaling.</description>
             <store>
+                <option>
+                    <value>inherited</value>
+                    <label lang="de">Vererbt</label>
+                    <label lang="en">Inherited</label>
+                    <label lang="nl">Geërfd</label>
+                </option>
                 <option>
                     <value>yes</value>
                     <label lang="de">Ja</label>


### PR DESCRIPTION
please test before merging

parts to test

* transition klarna order to a status that triggers the "shipping" in mollie
       * a) for an order from the main shop
       * b) for an order from a subshop with da different config

* ship truck icon in shopware backend
       * a) for an order from the main shop
       * b) for an order from a subshop with da different config

* refund action + partial refund
       * a) for an order from the main shop
       * b) for an order from a subshop with da different config
