### PR TITLE
Fixed JavaScript Error for the SubmitButtons while using CreditCard

### DIFF
--- a/Resources/views/frontend/_public/src/js/components.js
+++ b/Resources/views/frontend/_public/src/js/components.js
@@ -67,7 +67,7 @@ if (cardToken !== undefined) {
 
     const disableForm = () => {
         let submitButtons = document.querySelectorAll('button[type="submit"]');
-        if (submitButtons.length) {
+        if (submitButtons.length > 0) {
             submitButtons.forEach(function(el) {
                 el.disabled = true;
             });
@@ -76,7 +76,7 @@ if (cardToken !== undefined) {
 
     const enableForm = () => {
         let submitButtons = document.querySelectorAll('button[type="submit"]');
-        if (submitButtons.length) {
+        if (submitButtons.length > 0) {
             submitButtons.forEach(function(el) {
                 el.disabled = false;
             });

--- a/Resources/views/frontend/_public/src/js/components.js
+++ b/Resources/views/frontend/_public/src/js/components.js
@@ -66,16 +66,25 @@ if (cardToken !== undefined) {
     };
 
     const disableForm = () => {
-        submitButton.disabled = true;
+        let submitButtons = document.querySelectorAll('button[type="submit"]');
+        if (submitButtons.length) {
+            submitButtons.forEach(function(el) {
+                el.disabled = true;
+            });
+        }
     };
 
     const enableForm = () => {
-        submitButton.disabled = false;
+        let submitButtons = document.querySelectorAll('button[type="submit"]');
+        if (submitButtons.length) {
+            submitButtons.forEach(function(el) {
+                el.disabled = false;
+            });
+        }
     };
 
     // Elements
     const form = document.getElementById('shippingPaymentForm');
-    const submitButton = document.querySelector('button[type="submit"]');
 
     // Create inputs
     inputs.forEach((element, index, arr) => {


### PR DESCRIPTION
The Default Shopware Checkout has 2 "submit" Buttons.
One above the Shipping and Payment Methods and one below.

If CreditCard ist the first selected Component while opening the checkout, the JavaScript that selects the Submit button is executed directly instead of waiting until the DOM is ready.

In the default checkout this works because we have a submit button that was printed into the dom before the javascript was executed.

Customized Checkouts with only one submit button below the payment and shipping selection will cause an JavaScript Error:

components?ext=.js&ts=1599553913:69 Uncaught (in promise) TypeError: Cannot set property 'disabled' of null
    at disableForm (components?ext=.js&ts=1599553913:69)
    at HTMLFormElement.<anonymous> (components?ext=.js&ts=1599553913:112)

This pull request solves the problem by selecting the submit buttons on the click and selecting all buttons instead of the first found one.
This method also throws no error if no submit button was found