### PR TITLE
NTR: fix credit card components test mode due to new config

### DIFF
--- a/Controllers/Frontend/Mollie.php
+++ b/Controllers/Frontend/Mollie.php
@@ -978,7 +978,7 @@ class Shopware_Controllers_Frontend_Mollie extends AbstractPaymentController
         }
 
         if ($config !== null) {
-            $mollieTestMode = (strpos($config->apiKey(), 'test') === 0);
+            $mollieTestMode = $config->isTestmodeActive();
         }
 
         if ($mollieProfile !== null) {


### PR DESCRIPTION
credit card components have a test mode configuration
that needs to be changed to the new setting in the plugin