### PR TITLE
MOL-29: Fix Problem with sPayments = null which caused dead loading

### DIFF
--- a/Subscriber/ApplePayDirectSubscriber.php
+++ b/Subscriber/ApplePayDirectSubscriber.php
@@ -96,6 +96,10 @@ class ApplePayDirectSubscriber implements SubscriberInterface
         $view = $args->getSubject()->View();
 
         $sPayments = $view->getAssign('sPayments');
+        if ($sPayments === null) {
+            return;
+        }
+
         $this->removeApplePayDirectFromPaymentMeans($sPayments);
 
         $view->assign('sPayments', $sPayments);


### PR DESCRIPTION
On switch payment ajax request the sPayments variable is null which caused a 500 Response as removeApplePayDirectFromPaymentMeans only accepts arrays