### PR TITLE
MOL-30: Hide original Apple Pay on payment selection page

### DIFF
--- a/Resources/views/frontend/_public/src/js/applepay.js
+++ b/Resources/views/frontend/_public/src/js/applepay.js
@@ -1,0 +1,49 @@
+(function ($) {
+    "use strict";
+
+    $(document).ready(function() {
+        hideApplePayIfNotAllowed();
+    });
+
+    $(document).ajaxComplete(function() {
+        hideApplePayIfNotAllowed();
+    });
+
+    /**
+     * This function is used to hide Apple Pay if the visitor can't use it.
+     * Please keep in mind, this is Apple Pay and not Apple Pay Direct.
+     * So it just hides Apple Pay on the payment selection page.
+     */
+    function hideApplePayIfNotAllowed() {
+        // Find the hidden Apple Pay element
+        var applePayInput = document.getElementsByClassName('payment-mean-mollie-applepay');
+        var applePayLabel = document.getElementsByClassName('payment-mean-mollie-applepay-label');
+
+        // Create a disabled attribute
+        var disabledItem = document.createAttribute('disabled');
+        disabledItem.value = 'disabled';
+
+        if (!window.ApplePaySession || !ApplePaySession.canMakePayments()) {
+            // Apple Pay is not available
+            if (typeof applePayInput !== 'undefined' && applePayInput.length) {
+                applePayInput[0].checked = false;
+                applePayInput[0].attributes.setNamedItem(disabledItem);
+                applePayInput[0].parentNode.parentNode.classList.add('is--hidden');
+            }
+        } else {
+            // Show Apple Pay option
+            if (typeof applePayInput !== 'undefined' && applePayInput.length) {
+                if (applePayInput[0].attributes.getNamedItem('disabled') !== null) {
+                    applePayInput[0].attributes.removeNamedItem('disabled');
+                }
+
+                applePayInput[0].parentNode.parentNode.classList.remove('is--hidden');
+            }
+
+            if (typeof applePayLabel !== 'undefined' && applePayLabel.length) {
+                applePayLabel[0].classList.remove('is--soft');
+                applePayLabel[0].classList.remove('is--hidden');
+            }
+        }
+    }
+}(jQuery));

--- a/Subscriber/FrontendViewSubscriber.php
+++ b/Subscriber/FrontendViewSubscriber.php
@@ -126,6 +126,9 @@ class FrontendViewSubscriber implements SubscriberInterface
         // Create new array collection to add src files
         $collection = new ArrayCollection();
 
+        # this is used to hide the plain Apple Pay too, if not available for the user
+        $collection->add(__DIR__ . '/../Resources/views/frontend/_public/src/js/applepay.js');
+
         return $collection;
     }
 


### PR DESCRIPTION
the original apple pay was hidden, even its a default payment method...no one knew...that was the function

i've also renamed the function and improved descriptions