### PR TITLE
MOL-31: Fix broken order confirmation mail

### DIFF
--- a/Subscriber/OrderBackendSubscriber.php
+++ b/Subscriber/OrderBackendSubscriber.php
@@ -94,8 +94,6 @@ class OrderBackendSubscriber implements SubscriberInterface
                 }
             }
         }
-
-        return true;
     }
 
     /**


### PR DESCRIPTION
this was a notifyUntil call
so with the added return statement, the mail isn't sent anymore

i've reverted it to the way it was before..without any return for success