### PR TITLE
MOL-24: LineItem TotalAmount Correction

### DIFF
--- a/Controllers/Frontend/Mollie.php
+++ b/Controllers/Frontend/Mollie.php
@@ -498,7 +498,7 @@ class Shopware_Controllers_Frontend_Mollie extends AbstractPaymentController
                 $transactionItem->setQuantity($basketLine['quantity']);
                 $transactionItem->setUnitPrice($basketLine['unit_price']);
                 $transactionItem->setNetPrice($basketLine['net_price']);
-                $transactionItem->setTotalAmount($basketLine['total_amount']);
+                $transactionItem->setTotalAmount(round($basketLine['unit_price'],2) * $basketLine['quantity']);
                 $transactionItem->setVatRate($basketLine['vat_rate']);
                 $transactionItem->setVatAmount($basketLine['vat_amount']);
 


### PR DESCRIPTION
There was a problem with payment methods which check if the sum of lineItem totalAmount and order totalAmount are equal that the lineItem prices haven't been rounded to 2 decimals before they are multiplied by the ordered quantity.

If you have 2 products with a price like 100.66 net and a VAT rate of 16% the unitPrice is 116.7656. Shopware rounds this to 2x 116.77 with an order total of 233.54. With the old calculation it was 2x 116.7656 = 233.5312 which is rounded to 233.53 and differs from the order total by 0.01 and causes this error.