### PR TITLE
MOL-35: Improve ApplePay Direct Margins if hidden

### DIFF
--- a/Resources/views/frontend/_public/src/js/applepay-direct.js
+++ b/Resources/views/frontend/_public/src/js/applepay-direct.js
@@ -2,6 +2,7 @@ function initApplePay() {
     "use strict";
 
     var applePayApiVersion = 3;
+    var applePayDivSelector = '.apple-pay--container';
     var applePayButtonSelector = '.applepay-button';
 
     $(document).ready(function () {
@@ -12,8 +13,29 @@ function initApplePay() {
      *
      */
     function initApplePayButtons() {
+
+        // we need our wrapping div layer
+        // because that one will also be hidden to avoid any existing margins
+        // if no apple pay should be displayed at all
+        const divsApplePay = document.querySelectorAll(applePayDivSelector);
+
         if (!window.ApplePaySession || !window.ApplePaySession.canMakePayments()) {
+            // hide our wrapping apple pay div
+            // to avoid any wrong margins if no apple pay is displayed
+            if (divsApplePay) {
+                divsApplePay.forEach(function (div) {
+                    div.style.display = "none";
+                });
+            }
             return;
+        }
+
+        // show our apple pay div layer
+        // just in case it wasn't visible before
+        if (divsApplePay) {
+            divsApplePay.forEach(function (div) {
+                div.style.display = "inline-block";
+            });
         }
 
         var buttons = document.querySelectorAll(applePayButtonSelector);
@@ -257,16 +279,16 @@ function initApplePay() {
 initApplePay();
 
 // Reinits apple pay buttons
-$.subscribe('plugin/swAjaxVariant/onRequestDataCompleted', function() {
+$.subscribe('plugin/swAjaxVariant/onRequestDataCompleted', function () {
     initApplePay();
 });
 
 // we need to (re)initialize it
 // because we are loaded within an AJAX request
-$.subscribe('plugin/swCollapseCart/onLoadCartFinished', function() {
+$.subscribe('plugin/swCollapseCart/onLoadCartFinished', function () {
     initApplePay();
 });
 
-$.subscribe('plugin/swCollapseCart/onArticleAdded', function() {
+$.subscribe('plugin/swCollapseCart/onArticleAdded', function () {
     initApplePay();
 });

--- a/Resources/views/frontend/checkout/ajax_cart.tpl
+++ b/Resources/views/frontend/checkout/ajax_cart.tpl
@@ -2,9 +2,9 @@
 
 {block name="frontend_checkout_ajax_cart_button_container_inner"}
     {$smarty.block.parent}
-    {if $sBasket.content}
+    {if $sMollieApplePayDirectButton.active && $sBasket.content}
         {block name="frontend_checkout_ajax_cart_apple_pay_direct"}
-            <div class="apple-pay--container--ajax-cart">
+            <div class="apple-pay--container apple-pay--container--ajax-cart">
                 {include 'frontend/plugins/payment/mollie_applepay_direct.tpl' }
             </div>
         {/block}

--- a/Resources/views/frontend/checkout/cart.tpl
+++ b/Resources/views/frontend/checkout/cart.tpl
@@ -3,9 +3,9 @@
 
 {block name="frontend_checkout_actions_confirm"}
     {$smarty.block.parent}
-    {if !$sMinimumSurcharge && !($sDispatchNoOrder && !$sDispatches) && !$sInvalidCartItems}
+    {if $sMollieApplePayDirectButton.active && !$sMinimumSurcharge && !($sDispatchNoOrder && !$sDispatches) && !$sInvalidCartItems}
         {block name="frontend_checkout_apple_pay_direct_top"}
-            <div class="apple-pay--container--cart is--top">
+            <div class="apple-pay--container apple-pay--container--cart is--top">
                 {include 'frontend/plugins/payment/mollie_applepay_direct.tpl'}
             </div>
         {/block}
@@ -15,9 +15,9 @@
 
 {block name="frontend_checkout_actions_confirm_bottom"}
     {$smarty.block.parent}
-    {if !$sMinimumSurcharge && !($sDispatchNoOrder && !$sDispatches) && !$sInvalidCartItems}
+    {if $sMollieApplePayDirectButton.active && !$sMinimumSurcharge && !($sDispatchNoOrder && !$sDispatches) && !$sInvalidCartItems}
         {block name="frontend_checkout_apple_pay_direct_bottom"}
-            <div class="apple-pay--container--cart">
+            <div class="apple-pay--container apple-pay--container--cart">
                 {include 'frontend/plugins/payment/mollie_applepay_direct.tpl'}
             </div>
         {/block}

--- a/Resources/views/frontend/detail/buy.tpl
+++ b/Resources/views/frontend/detail/buy.tpl
@@ -2,9 +2,9 @@
 
 {block name="frontend_detail_buy_button"}
     {$smarty.block.parent}
-    {if !($sArticle.sConfigurator && !$activeConfiguratorSelection)}
+    {if $sMollieApplePayDirectButton.active && !($sArticle.sConfigurator && !$activeConfiguratorSelection)}
         {block name="frontend_detail_buy_button_includes_apple_pay_direct"}
-            <div class="apple-pay--container--detail">
+            <div class="apple-pay--container apple-pay--container--detail">
                 {include 'frontend/plugins/payment/mollie_applepay_direct.tpl' }
             </div>
         {/block}

--- a/Resources/views/frontend/plugins/payment/mollie_applepay_direct.tpl
+++ b/Resources/views/frontend/plugins/payment/mollie_applepay_direct.tpl
@@ -1,19 +1,17 @@
-{if $sMollieApplePayDirectButton.active}
-    <a class="applepay-button"
-       lang="{$smarty.server.HTTP_ACCEPT_LANGUAGE}"
-       style="-webkit-appearance: -apple-pay-button; -apple-pay-button-type: check-out; display: none;"
-       data-getshippingsurl="{url module=frontend controller="MollieApplePayDirect" action="getShippings" forceSecure}"
-       data-setshippingurl="{url module=frontend controller="MollieApplePayDirect" action="setShipping" forceSecure}"
-       data-restorecarturl="{url module=frontend controller="MollieApplePayDirect" action="restoreCart" forceSecure}"
-       data-validationurl="{url module=frontend controller="MollieApplePayDirect" action="createPaymentSession" forceSecure}"
-       data-checkouturl="{url module=frontend controller="MollieApplePayDirect" action="startPayment" forceSecure}"
-       data-label="{$sMollieApplePayDirectButton.label}"
-       data-amount="{$sMollieApplePayDirectButton.amount}"
-       data-country="{$sMollieApplePayDirectButton.country}"
-       data-currency="{$sMollieApplePayDirectButton.currency}"
-            {if $sMollieApplePayDirectButton.itemMode}
-                data-addproducturl="{url module=frontend controller="MollieApplePayDirect" action="addProduct" forceSecure}"
-                data-productnumber="{$sMollieApplePayDirectButton.addNumber}"
-            {/if}
-    ></a>
-{/if}
+<a class="applepay-button"
+   lang="{$smarty.server.HTTP_ACCEPT_LANGUAGE}"
+   style="-webkit-appearance: -apple-pay-button; -apple-pay-button-type: check-out; display: none;"
+   data-getshippingsurl="{url module=frontend controller="MollieApplePayDirect" action="getShippings" forceSecure}"
+   data-setshippingurl="{url module=frontend controller="MollieApplePayDirect" action="setShipping" forceSecure}"
+   data-restorecarturl="{url module=frontend controller="MollieApplePayDirect" action="restoreCart" forceSecure}"
+   data-validationurl="{url module=frontend controller="MollieApplePayDirect" action="createPaymentSession" forceSecure}"
+   data-checkouturl="{url module=frontend controller="MollieApplePayDirect" action="startPayment" forceSecure}"
+   data-label="{$sMollieApplePayDirectButton.label}"
+   data-amount="{$sMollieApplePayDirectButton.amount}"
+   data-country="{$sMollieApplePayDirectButton.country}"
+   data-currency="{$sMollieApplePayDirectButton.currency}"
+        {if $sMollieApplePayDirectButton.itemMode}
+            data-addproducturl="{url module=frontend controller="MollieApplePayDirect" action="addProduct" forceSecure}"
+            data-productnumber="{$sMollieApplePayDirectButton.addNumber}"
+        {/if}
+></a>


### PR DESCRIPTION
if apple pay wasnt visible there were still 10px margins from the wrapping div layer.
they should be removed

that layer depends on the place where its used

so i've moved the "active" IF condition to the integration templates.
every container does now have a generic applepay-container class name that will be used to show/hide 
the whole apple pay within javascript