### PR TITLE
NTR: remove diw and kiener

### DIFF
--- a/Components/Account/Account.php
+++ b/Components/Account/Account.php
@@ -5,9 +5,7 @@ namespace MollieShopware\Components\Account;
 use MollieShopware\Components\Account\Gateway\GuestAccountGatewayInterface;
 use Shopware\Components\Password\Manager;
 
-/**
- * @copyright 2020 dasistweb GmbH (https://www.dasistweb.de)
- */
+
 class Account
 {
 

--- a/Components/ApplePayDirect/ApplePayDirectFactory.php
+++ b/Components/ApplePayDirect/ApplePayDirectFactory.php
@@ -8,9 +8,7 @@ use MollieShopware\Components\Config;
 use MollieShopware\Components\MollieApiFactory;
 use MollieShopware\Components\Shipping\Shipping;
 
-/**
- * @copyright 2020 dasistweb GmbH (https://www.dasistweb.de)
- */
+
 class ApplePayDirectFactory
 {
 

--- a/Components/ApplePayDirect/ApplePayDirectHandlerInterface.php
+++ b/Components/ApplePayDirect/ApplePayDirectHandlerInterface.php
@@ -2,9 +2,7 @@
 
 namespace MollieShopware\Components\ApplePayDirect;
 
-/**
- * @copyright 2020 dasistweb GmbH (https://www.dasistweb.de)
- */
+
 interface ApplePayDirectHandlerInterface
 {
 

--- a/Components/ApplePayDirect/Handler/ApplePayDirectHandler.php
+++ b/Components/ApplePayDirect/Handler/ApplePayDirectHandler.php
@@ -7,9 +7,7 @@ use MollieShopware\Components\ApplePayDirect\ApplePayDirectHandlerInterface;
 use MollieShopware\Components\ApplePayDirect\Models\Cart\ApplePayCart;
 use MollieShopware\Components\Shipping\Shipping;
 
-/**
- * @copyright 2020 dasistweb GmbH (https://www.dasistweb.de)
- */
+
 class ApplePayDirectHandler implements ApplePayDirectHandlerInterface
 {
 

--- a/Components/ApplePayDirect/Models/Button/ApplePayButton.php
+++ b/Components/ApplePayDirect/Models/Button/ApplePayButton.php
@@ -2,10 +2,6 @@
 
 namespace MollieShopware\Components\ApplePayDirect\Models\Button;
 
-
-/**
- * @copyright 2020 dasistweb GmbH (https://www.dasistweb.de)
- */
 class ApplePayButton
 {
 

--- a/Components/ApplePayDirect/Models/Cart/ApplePayCart.php
+++ b/Components/ApplePayDirect/Models/Cart/ApplePayCart.php
@@ -3,9 +3,6 @@
 namespace MollieShopware\Components\ApplePayDirect\Models\Cart;
 
 
-/**
- * @copyright 2020 dasistweb GmbH (https://www.dasistweb.de)
- */
 class ApplePayCart
 {
     

--- a/Components/ApplePayDirect/Models/Cart/ApplePayLineItem.php
+++ b/Components/ApplePayDirect/Models/Cart/ApplePayLineItem.php
@@ -2,10 +2,6 @@
 
 namespace MollieShopware\Components\ApplePayDirect\Models\Cart;
 
-
-/**
- * @copyright 2020 dasistweb GmbH (https://www.dasistweb.de)
- */
 class ApplePayLineItem
 {
 

--- a/Components/Country/CountryIsoParser.php
+++ b/Components/Country/CountryIsoParser.php
@@ -2,9 +2,6 @@
 
 namespace MollieShopware\Components\Country;
 
-/**
- * @copyright 2020 dasistweb GmbH (https://www.dasistweb.de)
- */
 class CountryIsoParser
 {
 

--- a/Components/Order/OrderSession.php
+++ b/Components/Order/OrderSession.php
@@ -10,9 +10,6 @@ use Shopware\Models\Payment\Payment;
 use Shopware\Models\Payment\Repository;
 use Shopware_Controllers_Frontend_Checkout;
 
-/**
- * @copyright 2020 dasistweb GmbH (https://www.dasistweb.de)
- */
 class OrderSession
 {
 

--- a/Components/Shipping/Shipping.php
+++ b/Components/Shipping/Shipping.php
@@ -6,9 +6,6 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Enlight_Components_Session_Namespace;
 
-/**
- * @copyright 2020 dasistweb GmbH (https://www.dasistweb.de)
- */
 class Shipping
 {
     /**

--- a/Controllers/Frontend/MollieApplePayDirect.php
+++ b/Controllers/Frontend/MollieApplePayDirect.php
@@ -16,9 +16,6 @@ use Shopware\Bundle\StoreFrontBundle\Struct\ShopContext;
 use Shopware\Components\ContainerAwareEventManager;
 use Shopware\Components\CSRFWhitelistAware;
 
-/**
- * @copyright 2020 dasistweb GmbH (https://www.dasistweb.de)
- */
 class Shopware_Controllers_Frontend_MollieApplePayDirect extends Shopware_Controllers_Frontend_Checkout implements CSRFWhitelistAware
 {
 

--- a/Traits/MollieApiClientTrait.php
+++ b/Traits/MollieApiClientTrait.php
@@ -7,9 +7,6 @@ use Mollie\Api\MollieApiClient;
 use MollieShopware\Components\Logger;
 use MollieShopware\Components\MollieApiFactory;
 
-/**
- * @copyright 2020 dasistweb GmbH (https://www.dasistweb.de)
- */
 trait MollieApiClientTrait
 {
 

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,6 @@ Mollie offers various payment methods which can be easily integrated into your S
 
 Once the onboarding process in your Mollie account is completed, start accepting payments. You’ll usually be up and running within one working day.
 
-Maintenance of our official plugin is performed by our [Shopware development partner Kiener](https://www.kiener.nl/).
 
 ## Manual installation
 There are two ways of installing this plugin manually: You can either checkout this repository on your machine (in the plugins folder of your Shopware installation) or you can download the zip file above (most recent version can be found here: [master](https://github.com/mollie/Shopware/archive/master.zip)) and extract this on your machine (in the very same plugins folder).


### PR DESCRIPTION
we remove diw and kiener infos from the plugin to have it "branded" for mollie.

this should avoid direct agency support. its planned to do 1st level support only thru the official mollie support