### PR TITLE
MOL-42: Fix missing refund status in webhooks

### DIFF
--- a/Components/Constants/PaymentStatus.php
+++ b/Components/Constants/PaymentStatus.php
@@ -12,4 +12,16 @@ class PaymentStatus
     const MOLLIE_PAYMENT_CANCELED = 'canceled';
     const MOLLIE_PAYMENT_EXPIRED = 'expired';
     const MOLLIE_PAYMENT_FAILED = 'failed';
+
+    /**
+     * attention!
+     * mollie has no status for refunds. its always "paid", but
+     * the payment itself has additional refund keys and values.
+     * we still need a status for order transitions and more due to
+     * the plugin architecture. so we've added our fictional status entries here!
+     * these will never come from the mollie API
+     */
+    const MOLLIE_PAYMENT_REFUNDED = 'refunded';
+    const MOLLIE_PAYMENT_PARTIALLY_REFUNDED = 'partially_refunded';
+    
 }

--- a/Components/Helpers/MollieRefundStatus.php
+++ b/Components/Helpers/MollieRefundStatus.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace MollieShopware\Components\Helpers;
+
+use Mollie\Api\Resources\Order;
+use Shopware\Models\Payment\Payment;
+
+class MollieRefundStatus
+{
+
+    /**
+     * Gets if the provided payment has been fully refunded.
+     *
+     * @param Payment $payment
+     * @return bool
+     */
+    public function isPaymentFullyRefunded(Payment $payment)
+    {
+        if ($payment->isPaid() && $payment->getAmountRefunded() > 0 && $payment->getAmountRemaining() <= 0) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Gets if the provided payment has been at least
+     * partially refunded.
+     *
+     * @param Payment $payment
+     * @return bool
+     */
+    public function isPaymentPartiallyRefunded(Payment $payment)
+    {
+        if ($payment->isPaid() && $payment->getAmountRefunded() > 0 && $payment->getAmountRemaining() > 0) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Gets if the provided order is fully refunded.
+     *
+     * @param Order $order
+     * @return bool
+     */
+    public function isOrderFullyRefunded(Order $order)
+    {
+        if ($order->amountRefunded === null) {
+            return false;
+        }
+
+        $orderValue = $order->amount->value;
+        $refundedValue = $order->amountRefunded->value;
+
+        # both of them are strings, but that's totally fine
+        return ($orderValue === $refundedValue);
+    }
+
+    /**
+     * Gets if the provided order is partially refunded.
+     *
+     * @param Order $order
+     * @return bool
+     */
+    public function isOrderPartiallyRefunded(Order $order)
+    {
+        if ($order->amountRefunded === null) {
+            return false;
+        }
+
+        $orderValue = $order->amount->value;
+        $refundedValue = $order->amountRefunded->value;
+
+        # both of them are strings, but that's totally fine
+        return ($orderValue !== $refundedValue);
+    }
+
+}


### PR DESCRIPTION
notification of refunded orders have always been converted to "paid" again, which is wrong.

the problem is, that the status is still "paid" but optional refund data exists that need to be queried.

the hard thing was to add that without the risk of side effects.
so i've created a refund class that just asks for either full or partial refunds of both payments and orders in mollie.

the integration has then be done equal to the existing ones to avoid side effects