### PR TITLE
MOL-41: Apple Pay Direct with logged in Shop Account

### DIFF
--- a/Components/Account/Account.php
+++ b/Components/Account/Account.php
@@ -61,6 +61,18 @@ class Account
     }
 
     /**
+     * Gets if the user is already signed in.
+     * 
+     * @return bool
+     */
+    public function isLoggedIn()
+    {
+        $userId = $this->session->offsetGet('sUserId');
+
+        return !empty($userId);
+    }
+
+    /**
      * @param string $email
      * @param string $firstname
      * @param string $lastname

--- a/Components/ApplePayDirect/ApplePayDirectHandlerInterface.php
+++ b/Components/ApplePayDirect/ApplePayDirectHandlerInterface.php
@@ -3,6 +3,9 @@
 namespace MollieShopware\Components\ApplePayDirect;
 
 
+use MollieShopware\Components\ApplePayDirect\Handler\ApplePayDirectHandler;
+use MollieShopware\Components\ApplePayDirect\Models\UserData\UserData;
+
 interface ApplePayDirectHandlerInterface
 {
 
@@ -17,6 +20,21 @@ interface ApplePayDirectHandlerInterface
      * @return mixed
      */
     public function requestPaymentSession($domain, $validationUrl);
+
+    /**
+     * @param UserData $userData
+     */
+    public function setUserData(UserData $userData);
+
+    /**
+     * @return UserData|null
+     */
+    public function getUserData();
+
+    /**
+     * @return mixed
+     */
+    public function clearUserData();
 
     /**
      * @param $token

--- a/Components/ApplePayDirect/Handler/ApplePayDirectHandler.php
+++ b/Components/ApplePayDirect/Handler/ApplePayDirectHandler.php
@@ -5,6 +5,7 @@ namespace MollieShopware\Components\ApplePayDirect\Handler;
 use Mollie\Api\MollieApiClient;
 use MollieShopware\Components\ApplePayDirect\ApplePayDirectHandlerInterface;
 use MollieShopware\Components\ApplePayDirect\Models\Cart\ApplePayCart;
+use MollieShopware\Components\ApplePayDirect\Models\UserData\UserData;
 use MollieShopware\Components\Shipping\Shipping;
 
 
@@ -18,6 +19,12 @@ class ApplePayDirectHandler implements ApplePayDirectHandlerInterface
      */
     const KEY_SESSION_PAYMENTTOKEN = 'MOLLIE_APPLEPAY_PAYMENTTOKEN';
 
+    /**
+     * This is the key for the session entry
+     * that stores the entered user data of the
+     * apple pay customer.
+     */
+    const KEY_SESSION_USERDATA = 'MOLLIE_APPLEPAY_USERDATA';
 
     /**
      * @var MollieApiClient
@@ -93,7 +100,7 @@ class ApplePayDirectHandler implements ApplePayDirectHandlerInterface
 
         /** @var array $shipping */
         $shipping = $this->admin->sGetPremiumShippingcosts($country);
-        
+
         if ($shipping['brutto'] !== null && $shipping['brutto'] > 0) {
 
             /** @var array $shipmentMethod */
@@ -130,6 +137,34 @@ class ApplePayDirectHandler implements ApplePayDirectHandlerInterface
         );
 
         return (string)$responseString;
+    }
+
+    /**
+     * Sets the user data from the Apple Pay payment sheet.
+     *
+     * @param UserData $userData
+     */
+    public function setUserData(UserData $userData)
+    {
+        $this->session->offsetSet(self::KEY_SESSION_USERDATA, $userData);
+    }
+
+    /**
+     * Gets the user data from the Apple Pay payment sheet.
+     *
+     * @return null|UserData
+     */
+    public function getUserData()
+    {
+        return $this->session->offsetGet(self::KEY_SESSION_USERDATA);
+    }
+
+    /**
+     * Clears the user data in the session
+     */
+    public function clearUserData()
+    {
+        $this->session->offsetSet(self::KEY_SESSION_USERDATA, null);
     }
 
     /**

--- a/Components/ApplePayDirect/Models/UserData/UserData.php
+++ b/Components/ApplePayDirect/Models/UserData/UserData.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace MollieShopware\Components\ApplePayDirect\Models\UserData;
+
+
+class UserData
+{
+
+    /**
+     * @var string
+     */
+    private $email;
+
+    /**
+     * @var string
+     */
+    private $firstname;
+
+    /**
+     * @var string
+     */
+    private $lastname;
+
+    /**
+     * @var string
+     */
+    private $street;
+
+    /**
+     * @var string
+     */
+    private $zipcode;
+
+    /**
+     * @var string
+     */
+    private $city;
+
+    /**
+     * @var string
+     */
+    private $countryCode;
+
+    
+    /**
+     * UserData constructor.
+     * @param $email
+     * @param $firstname
+     * @param $lastname
+     * @param $street
+     * @param $zipcode
+     * @param $city
+     * @param $countryCode
+     */
+    public function __construct($email, $firstname, $lastname, $street, $zipcode, $city, $countryCode)
+    {
+        $this->email = $email;
+        $this->firstname = $firstname;
+        $this->lastname = $lastname;
+        $this->street = $street;
+        $this->zipcode = $zipcode;
+        $this->city = $city;
+        $this->countryCode = $countryCode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEmail()
+    {
+        return $this->email;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFirstname()
+    {
+        return $this->firstname;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLastname()
+    {
+        return $this->lastname;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStreet()
+    {
+        return $this->street;
+    }
+
+    /**
+     * @return string
+     */
+    public function getZipcode()
+    {
+        return $this->zipcode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCity()
+    {
+        return $this->city;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCountryCode()
+    {
+        return $this->countryCode;
+    }
+
+}

--- a/Components/Order/OrderAddress.php
+++ b/Components/Order/OrderAddress.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace MollieShopware\Components\Order;
+
+class OrderAddress
+{
+    /**
+     * @var string
+     */
+    private $firstname;
+
+    /**
+     * @var string
+     */
+    private $lastname;
+
+    /**
+     * @var string
+     */
+    private $street;
+
+    /**
+     * @var string
+     */
+    private $zipcode;
+
+    /**
+     * @var string
+     */
+    private $city;
+
+    /**
+     * @var array
+     */
+    private $country;
+
+    /**
+     * OrderAddress constructor.
+     * @param string $firstname
+     * @param string $lastname
+     * @param string $street
+     * @param string $zipcode
+     * @param string $city
+     * @param array $country
+     */
+    public function __construct($firstname, $lastname, $street, $zipcode, $city, $country)
+    {
+        $this->firstname = $firstname;
+        $this->lastname = $lastname;
+        $this->street = $street;
+        $this->zipcode = $zipcode;
+        $this->city = $city;
+        $this->country = $country;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFirstname()
+    {
+        return $this->firstname;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLastname()
+    {
+        return $this->lastname;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStreet()
+    {
+        return $this->street;
+    }
+
+    /**
+     * @return string
+     */
+    public function getZipcode()
+    {
+        return $this->zipcode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCity()
+    {
+        return $this->city;
+    }
+
+    /**
+     * @return array
+     */
+    public function getCountry()
+    {
+        return $this->country;
+    }
+
+}

--- a/Components/Order/OrderSession.php
+++ b/Components/Order/OrderSession.php
@@ -41,6 +41,35 @@ class OrderSession
         $this->repoPayments = Shopware()->Container()->get('models')->getRepository(Payment::class);
     }
 
+    /**
+     * This function allows you to set a custom address object
+     * before creating the actual order in the session.
+     *
+     * @param Shopware_Controllers_Frontend_Checkout $checkoutController
+     * @param OrderAddress $address
+     */
+    public function setCustomerData(Shopware_Controllers_Frontend_Checkout $checkoutController, OrderAddress $address)
+    {
+        $userData = $checkoutController->View()->getAssign('sUserData');
+
+        $userData['billingaddress']['firstname'] = $address->getFirstname();
+        $userData['billingaddress']['lastname'] = $address->getLastname();
+        $userData['billingaddress']['street'] = $address->getStreet();
+        $userData['billingaddress']['zipcode'] = $address->getZipcode();
+        $userData['billingaddress']['city'] = $address->getCity();
+        $userData['billingaddress']['countryId'] = $address->getCountry()['id'];
+        $userData['billingaddress']['country'] = $address->getCountry();
+
+        $userData['shippingaddress']['firstname'] = $address->getFirstname();
+        $userData['shippingaddress']['lastname'] = $address->getLastname();
+        $userData['shippingaddress']['street'] = $address->getStreet();
+        $userData['shippingaddress']['zipcode'] = $address->getZipcode();
+        $userData['shippingaddress']['city'] = $address->getCity();
+        $userData['shippingaddress']['countryId'] = $address->getCountry()['id'];
+        $userData['shippingaddress']['country'] = $address->getCountry();
+
+        $checkoutController->View()->assign('sUserData', $userData);
+    }
 
     /**
      * @param Shopware_Controllers_Frontend_Checkout $checkoutController
@@ -77,8 +106,7 @@ class OrderSession
         # created guest user
         $sOrderVariables['sUserData'] = $checkoutController->View()->getAssign('sUserData');
 
-        # make sure we always use "apple pay direct"
-        # for the order we create
+        # make sure we always use our payment method for the order we create
         $sOrderVariables['sUserData'] ['additional']['user']['paymentID'] = $paymentMethod->getId();
         $sOrderVariables['sUserData'] ['additional']['payment'] = $this->mockPaymentLegacyStructConverter($paymentMethod, $shopContext);
 


### PR DESCRIPTION
if the user is already signed in, apple pay direct should use this user instead of creating a guest account.

the user data by apple pay is now stored in the session.

if required, a guest account is being created.

however in both cases, it will be ensured that the order will get the data from apple pay