### PR TITLE
MOL-33: add Apple Pay Direct display option

### DIFF
--- a/Components/ApplePayDirect/Models/Button/ApplePayButton.php
+++ b/Components/ApplePayDirect/Models/Button/ApplePayButton.php
@@ -25,6 +25,16 @@ class ApplePayButton
      */
     private $addNumber;
 
+    /**
+     * @var DisplayOption[]
+     */
+    private $displayOption;
+
+    /**
+     * @var int[]
+     */
+    private $restrictionIds;
+
 
     /**
      * @param bool $active
@@ -36,6 +46,9 @@ class ApplePayButton
         $this->active = $active;
         $this->country = $country;
         $this->currency = $currency;
+
+        $this->displayOption = array();
+        $this->restrictionIds = array();
     }
 
     /**
@@ -55,6 +68,22 @@ class ApplePayButton
     }
 
     /**
+     * Adds a new display option to the apple pay button.
+     * If a restriction exists, it might not be visible in that place.
+     *
+     * @param DisplayOption $option
+     * @param bool $isRestricted
+     */
+    public function addDisplayOption(DisplayOption $option, $isRestricted)
+    {
+        if ($isRestricted) {
+            $this->restrictionIds[] = $option->getId();
+        }
+
+        $this->displayOption[] = $option;
+    }
+
+    /**
      * @return bool[]
      */
     public function toArray()
@@ -64,10 +93,23 @@ class ApplePayButton
             'country' => $this->country,
             'currency' => $this->currency,
             'itemMode' => $this->isItemMode(),
+            'displayOptions' => array(),
         );
 
         if ($this->isItemMode()) {
             $data['addNumber'] = $this->addNumber;
+        }
+
+        # add all our restrictions and
+        # make sure they are marked as "hidden"
+        /** @var DisplayOption $option */
+        foreach ($this->displayOption as $option) {
+
+            $isRestricted = in_array($option->getId(), $this->restrictionIds, true);
+
+            $data['displayOptions'][$option->getSmartyKey()] = array(
+                'visible' => !$isRestricted,
+            );
         }
 
         return $data;

--- a/Components/ApplePayDirect/Models/Button/DisplayOption.php
+++ b/Components/ApplePayDirect/Models/Button/DisplayOption.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace MollieShopware\Components\ApplePayDirect\Models\Button;
+
+class DisplayOption
+{
+
+    /**
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @var string
+     */
+    private $smartyKey;
+
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @param int $id
+     * @param string $smartyKey
+     * @param string $name
+     */
+    public function __construct($id, $smartyKey, $name)
+    {
+        $this->id = $id;
+        $this->smartyKey = $smartyKey;
+        $this->name = $name;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSmartyKey()
+    {
+        return $this->smartyKey;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+}

--- a/Components/ApplePayDirect/Services/ApplePayButtonBuilder.php
+++ b/Components/ApplePayDirect/Services/ApplePayButtonBuilder.php
@@ -5,6 +5,8 @@ namespace MollieShopware\Components\ApplePayDirect\Services;
 use Enlight_Controller_Request_Request;
 use Enlight_View;
 use MollieShopware\Components\ApplePayDirect\Models\Button\ApplePayButton;
+use MollieShopware\Components\ApplePayDirect\Models\Button\DisplayOption;
+use MollieShopware\Components\Config;
 use MollieShopware\Components\Country\CountryIsoParser;
 use Shopware\Models\Shop\Shop;
 
@@ -20,6 +22,11 @@ class ApplePayButtonBuilder
 
 
     /**
+     * @var Config
+     */
+    private $config;
+
+    /**
      * @var \sAdmin
      */
     private $sAdmin;
@@ -29,12 +36,22 @@ class ApplePayButtonBuilder
      */
     private $applePayPaymentMethod;
 
+    /**
+     * @var ApplePayDirectDisplayOptions
+     */
+    private $restrictionService;
+
 
     /**
+     * @param Config $config
      * @param ApplePayPaymentMethod $applePayPaymentMethod
+     * @param ApplePayDirectDisplayOptions $restrictionService
      */
-    public function __construct(ApplePayPaymentMethod $applePayPaymentMethod)
+    public function __construct(Config $config, ApplePayPaymentMethod $applePayPaymentMethod, ApplePayDirectDisplayOptions $restrictionService)
     {
+        $this->config = $config;
+        $this->restrictionService = $restrictionService;
+
         # attention, modules does not exist in CLI
         $this->sAdmin = Shopware()->Modules()->Admin();
         $this->applePayPaymentMethod = $applePayPaymentMethod;
@@ -67,6 +84,18 @@ class ApplePayButtonBuilder
             $shop->getCurrency()->getCurrency()
         );
 
+
+        # add our custom restrictions so that
+        # we know when the button must not be displayed
+        $pluginRestrictions = $this->config->getApplePayDirectRestrictions();
+
+        /** @var DisplayOption $option */
+        foreach ($this->restrictionService->getDisplayOptions() as $option) {
+            # see if we have it restricted in our plugin
+            $isRestricted = in_array($option->getId(), $pluginRestrictions, true);
+            # add our restriction settings
+            $button->addDisplayOption($option, $isRestricted);
+        }
 
         # now decide if we want to set our button to "item mode".
         # this means, that only this item will be sold

--- a/Components/ApplePayDirect/Services/ApplePayDirectDisplayOptions.php
+++ b/Components/ApplePayDirect/Services/ApplePayDirectDisplayOptions.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace MollieShopware\Components\ApplePayDirect\Services;
+
+use MollieShopware\Components\ApplePayDirect\Models\Button\DisplayOption;
+
+class ApplePayDirectDisplayOptions
+{
+
+    /**
+     * Gets a list of all available display options
+     * for Apple Pay Direct.
+     *
+     * @return array
+     */
+    public function getDisplayOptions()
+    {
+        $restrictions = array();
+
+        $restrictions[] = new DisplayOption(1, 'pdp', 'Product Detail Page');
+        $restrictions[] = new DisplayOption(2, 'cart', 'Cart');
+        $restrictions[] = new DisplayOption(3, 'cart_offcanvas', 'Cart (Offcanvas)');
+
+        return $restrictions;
+    }
+
+}

--- a/Components/Config.php
+++ b/Components/Config.php
@@ -349,4 +349,22 @@ class Config
         return (int) $userId;
     }
 
+    /**
+     * Gets a list of restrictions for the
+     * Apple Pay Direct integration.
+     *
+     * @return array
+     */
+    public function getApplePayDirectRestrictions()
+    {
+        /** @var array|null $restrictions */
+        $restrictions = $this->get('mollie_applepaydirect_restrictions');
+
+        if ($restrictions === null) {
+            return array();
+        }
+
+        return $restrictions;
+    }
+
 }

--- a/Controllers/Backend/MollieApplePayDirect.php
+++ b/Controllers/Backend/MollieApplePayDirect.php
@@ -1,0 +1,44 @@
+<?php
+
+use MollieShopware\Components\ApplePayDirect\Models\Button\DisplayOption;
+use MollieShopware\Components\ApplePayDirect\Services\ApplePayDirectDisplayOptions;
+
+class Shopware_Controllers_Backend_MollieApplePayDirect extends Shopware_Controllers_Backend_Application
+{
+
+    /**
+     * We have to set a model for every backend controller.
+     * So let's just use this one.
+     */
+    protected $model = \MollieShopware\Models\Transaction::class;
+    protected $alias = 'mollie_order';
+
+    /**
+     * Gets the available display restrictions of Apple Pay Direct.
+     * This is used for the multi select dropdown in the plugin configuration.
+     */
+    public function displayRestrictionsAction()
+    {
+        /** @var ApplePayDirectDisplayOptions $restrictionServices */
+        $restrictionServices = Shopware()->Container()->get('mollie_shopware.components.apple_pay_direct.services.display_option');
+
+        $restrictions = $restrictionServices->getDisplayOptions();
+
+        $data = [];
+
+        /** @var DisplayOption $options */
+        foreach ($restrictions as $options) {
+
+            $data[] = array(
+                'id' => $options->getId(),
+                'name' => $options->getName(),
+            );
+        }
+
+        $this->view->assign([
+            'data' => $data,
+            'total' => count($data),
+        ]);
+    }
+
+}

--- a/Resources/config.xml
+++ b/Resources/config.xml
@@ -372,5 +372,41 @@
             <label lang="nl">Gebruikers ID voor Mollie-gebruiker in Shopware</label>
         </element>
 
+        <element type="select" scope="shop">
+            <name>mollie_applepaydirect_restrictions</name>
+            <label lang="en">Apple Pay Direct Restrictions</label>
+            <label lang="de">Apple Pay Direct Einschränkungen</label>
+            <label lang="nl">Apple Pay Direct Beperkingen</label>
+            <description lang="en">Restrict Apple Pay Direct from being displayed on these pages.</description>
+            <description lang="de">Verhindere die Anzeige von Apple Pay Direct auf den hier gewählten Seiten</description>
+            <description lang="nl">Voorkom dat Apple Pay Direct wordt weergegeven op deze pagina's.</description>
+            <store><![CDATA[Ext.define('Mollie.ApplePayDirect.RestrictionsForm', {
+    extend: 'Ext.data.Store',
+    fields: [
+        { name:'id', type: 'int' },
+        { name:'name', type: 'string' }
+    ],
+    autoLoad: true,
+    pageSize: 25,
+    proxy: {
+        type: 'ajax',
+        url: window.location.href.substr(0, window.location.href.indexOf('backend')) + 'backend/MollieApplePayDirect/displayRestrictions',
+        reader: {
+            type: 'json',
+            root: 'data',
+            totalProperty: 'total'
+        }
+    }
+    }).create();//new ]]>
+            </store>
+            <options>
+                <multiSelect>true</multiSelect>
+                <valueField>id</valueField>
+                <displayField>name</displayField>
+                <isCustomStore>true</isCustomStore>
+            </options>
+        </element>
+
+
     </elements>
 </config>

--- a/Resources/services/applepay_direct.xml
+++ b/Resources/services/applepay_direct.xml
@@ -17,7 +17,9 @@
 
         <service id="mollie_shopware.components.apple_pay_direct.services.button_builder"
                  class="MollieShopware\Components\ApplePayDirect\Services\ApplePayButtonBuilder">
+            <argument type="service" id="mollie_shopware.config"/>
             <argument type="service" id="mollie_shopware.components.apple_pay_direct.services.payment_method"/>
+            <argument type="service" id="mollie_shopware.components.apple_pay_direct.services.display_option"/>
         </service>
 
         <service id="mollie_shopware.components.apple_pay_direct.services.formatter"
@@ -32,7 +34,11 @@
             <argument type="service" id="mollie_shopware.components.shipping"/>
             <argument type="service" id="session"/>
         </service>
-        
+
+        <service id="mollie_shopware.components.apple_pay_direct.services.display_option"
+                 class="MollieShopware\Components\ApplePayDirect\Services\ApplePayDirectDisplayOptions">
+        </service>
+
         <!-- Event Subscribers -->
         <!-- _______________________________________________________________________________________________________ -->
 

--- a/Resources/views/frontend/checkout/ajax_cart.tpl
+++ b/Resources/views/frontend/checkout/ajax_cart.tpl
@@ -2,7 +2,7 @@
 
 {block name="frontend_checkout_ajax_cart_button_container_inner"}
     {$smarty.block.parent}
-    {if $sMollieApplePayDirectButton.active && $sBasket.content}
+    {if $sMollieApplePayDirectButton.active && $sMollieApplePayDirectButton.displayOptions.cart_offcanvas.visible && $sBasket.content}
         {block name="frontend_checkout_ajax_cart_apple_pay_direct"}
             <div class="apple-pay--container apple-pay--container--ajax-cart">
                 {include 'frontend/plugins/payment/mollie_applepay_direct.tpl' }

--- a/Resources/views/frontend/checkout/cart.tpl
+++ b/Resources/views/frontend/checkout/cart.tpl
@@ -3,7 +3,7 @@
 
 {block name="frontend_checkout_actions_confirm"}
     {$smarty.block.parent}
-    {if $sMollieApplePayDirectButton.active && !$sMinimumSurcharge && !($sDispatchNoOrder && !$sDispatches) && !$sInvalidCartItems}
+    {if $sMollieApplePayDirectButton.active && $sMollieApplePayDirectButton.displayOptions.cart.visible && !$sMinimumSurcharge && !($sDispatchNoOrder && !$sDispatches) && !$sInvalidCartItems}
         {block name="frontend_checkout_apple_pay_direct_top"}
             <div class="apple-pay--container apple-pay--container--cart is--top">
                 {include 'frontend/plugins/payment/mollie_applepay_direct.tpl'}
@@ -15,7 +15,7 @@
 
 {block name="frontend_checkout_actions_confirm_bottom"}
     {$smarty.block.parent}
-    {if $sMollieApplePayDirectButton.active && !$sMinimumSurcharge && !($sDispatchNoOrder && !$sDispatches) && !$sInvalidCartItems}
+    {if $sMollieApplePayDirectButton.active && $sMollieApplePayDirectButton.displayOptions.cart.visible && !$sMinimumSurcharge && !($sDispatchNoOrder && !$sDispatches) && !$sInvalidCartItems}
         {block name="frontend_checkout_apple_pay_direct_bottom"}
             <div class="apple-pay--container apple-pay--container--cart">
                 {include 'frontend/plugins/payment/mollie_applepay_direct.tpl'}

--- a/Resources/views/frontend/detail/buy.tpl
+++ b/Resources/views/frontend/detail/buy.tpl
@@ -2,7 +2,7 @@
 
 {block name="frontend_detail_buy_button"}
     {$smarty.block.parent}
-    {if $sMollieApplePayDirectButton.active && !($sArticle.sConfigurator && !$activeConfiguratorSelection)}
+    {if $sMollieApplePayDirectButton.active && $sMollieApplePayDirectButton.displayOptions.pdp.visible && !($sArticle.sConfigurator && !$activeConfiguratorSelection)}
         {block name="frontend_detail_buy_button_includes_apple_pay_direct"}
             <div class="apple-pay--container apple-pay--container--detail">
                 {include 'frontend/plugins/payment/mollie_applepay_direct.tpl' }


### PR DESCRIPTION
added new plugin configuration to restrict the apple pay direct display on certain pages.

the button settings do now come with display options, where a restriction would lead to "visible = false"

![Screenshot 2020-10-20 at 10 06 40](https://user-images.githubusercontent.com/5579326/96558541-1deaa280-12bc-11eb-8e25-a2d0518c5e2a.png)
