### PR TITLE
MOL-42: Fix wrong namespace for refund webhooks

### DIFF
--- a/Components/Helpers/MollieRefundStatus.php
+++ b/Components/Helpers/MollieRefundStatus.php
@@ -3,7 +3,7 @@
 namespace MollieShopware\Components\Helpers;
 
 use Mollie\Api\Resources\Order;
-use Shopware\Models\Payment\Payment;
+use Mollie\Api\Resources\Payment;
 
 class MollieRefundStatus
 {


### PR DESCRIPTION
accidentally used shopware namespace which causes problems.

muas irgendwie eini grutscht sei beim commit, duad ma lad, gott sei dank gibts ja ne qa phase :) 