### PR TITLE
MOL-74: Fix broken payment installation without Live API key

### DIFF
--- a/Components/Services/PaymentMethodService.php
+++ b/Components/Services/PaymentMethodService.php
@@ -111,7 +111,15 @@ class PaymentMethodService
         $position = 0;
 
         /** @var null|MethodCollection $methods */
-        $methods = $this->appendApplePayDirectFeature($this->getActivePaymentMethodsFromMollie());
+        $methods = $this->getActivePaymentMethodsFromMollie();
+
+        if ($methods !== null) {
+            # if its not null, do the same again
+            # please note we give the original list into it
+            # to avoid duplicate adding (without changing anything else)
+            $methods = $this->appendApplePayDirectFeature($this->getActivePaymentMethodsFromMollie());
+        }
+
 
         // Add the template directory to the template manager
         $this->templateManager->addTemplateDir(__DIR__ . '/Resources/views');


### PR DESCRIPTION
somehow getActivePaymentMethodsFromMollie is null
this seems to be due to a missing api key

i think there is something weird anyway in the installation process
i'just tried to avoid that exception, then it works and just doesnt install anything

could you double check @barbieswimcrew  (that was your code - just to be sure)