### PR TITLE
MOL-73: Hide ExtJS error for ApplePay Display restrictions

### DIFF
--- a/Resources/config.xml
+++ b/Resources/config.xml
@@ -452,6 +452,11 @@
             type: 'json',
             root: 'data',
             totalProperty: 'total'
+        },
+        listeners: {
+            exception: function(store, response, operation) {
+                throw new Error('Please clear your cache to use the Apple Pay Display restrictions and reopen the configuration!');
+            }
         }
     }
     }).create();//new ]]>


### PR DESCRIPTION
if plugin is installed and cache is not cleared, the configuration backend URL does not yet exist, which leads to a huge extJs error display

the only solution now is, to throw an exception with a message and avoid that huge alert from being displayed