### PR TITLE
MOL-71: Compatibility Fix for empty payment ID

### DIFF
--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -154,5 +154,10 @@
             <tag name="shopware.event_subscriber"/>
         </service>
 
+        <service id="mollie_shopware.subscriber.compatibility.order_empty_payment" class="MollieShopware\Subscriber\Compatibility\OrderEmptyPaymentSubscriber">
+            <argument type="service" id="session"/>
+            <tag name="shopware.event_subscriber"/>
+        </service>
+
     </services>
 </container>

--- a/Subscriber/Compatibility/OrderEmptyPaymentSubscriber.php
+++ b/Subscriber/Compatibility/OrderEmptyPaymentSubscriber.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace MollieShopware\Subscriber\Compatibility;
+
+use Enlight\Event\SubscriberInterface;
+
+class OrderEmptyPaymentSubscriber implements SubscriberInterface
+{
+
+    /**
+     * This is the session key for the paymentID backup.
+     * The session will be set when starting the checkout
+     * and should contain the currently used paymentID.
+     */
+    const KEY_SESSION_PAYMENT_ID_BACKUP = 'MOLLIE_PAYMENT_ID_BACKUP';
+
+    /**
+     * @var \Enlight_Components_Session_Namespace
+     */
+    private $session;
+
+
+    /**
+     * @param \Enlight_Components_Session_Namespace $session
+     */
+    public function __construct(\Enlight_Components_Session_Namespace $session)
+    {
+        $this->session = $session;
+    }
+
+
+    /**
+     * @return array|string[]
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            'Shopware_Modules_Order_SaveOrder_FilterParams' => 'onSaveOrderFilterParams',
+        ];
+    }
+
+    /**
+     * This function fixes a rare issue where a payment ID is suddenly NULL.
+     * If the setting is "create orders after payment" that would mean
+     * that no order can be created, but the user is already charged in Mollie.
+     *
+     * @param \Enlight_Event_EventArgs $args
+     */
+    public function onSaveOrderFilterParams(\Enlight_Event_EventArgs $args)
+    {
+        /** @var array $data */
+        $data = $args->getReturn();
+
+        $paymentId = $data['paymentID'];
+
+        if ($paymentId === null) {
+
+            $backupPaymentID = $this->session->offsetGet(self::KEY_SESSION_PAYMENT_ID_BACKUP);
+
+            # set the correct payment for the
+            # variables that will be used for s_order
+            $data['paymentID'] = $backupPaymentID;
+
+            # also set the payment that will be used
+            # for s_core_payment_instance and also the "last used"
+            # payment of the user.
+            $orderVariables = $this->session->offsetGet('sOrderVariables');
+            $orderVariables['sUserData']['additional']['user']['paymentID'] = $backupPaymentID;
+            $this->session->offsetSet('sOrderVariables', $orderVariables);
+        }
+
+        $args->setReturn($data);
+    }
+
+}


### PR DESCRIPTION
sometimes the payment ID is somehow NULL and sSaveOrder throws an exception

that means that that order will not be saved, which is indeed a problem

we have no clue why the paymentID is somehow NULL...maybe hooks, events or other plugins?

so to fix this, the paymentID will be kept in a separate session key.
if its somehow NULL, we just restore that paymentID and set it again in our session
(worked while simulating it)