### PR TITLE
MOL-75: Rounding Refactoring fix Shipping Costs

### DIFF
--- a/Components/TransactionBuilder/Models/BasketItem.php
+++ b/Components/TransactionBuilder/Models/BasketItem.php
@@ -56,6 +56,12 @@ class BasketItem
     private $taxRate;
 
     /**
+     * @var bool
+     */
+    private $isNetMode;
+
+
+    /**
      * @param int $id
      * @param int $articleID
      * @param string $orderNumber
@@ -79,6 +85,8 @@ class BasketItem
         $this->unitPriceNet = $unitPriceNet;
         $this->quantity = $quantity;
         $this->taxRate = $taxRate;
+
+        $this->isNetMode = false;
     }
 
     /**
@@ -134,6 +142,10 @@ class BasketItem
      */
     public function getUnitPrice()
     {
+        if ($this->isNetMode) {
+            return $this->unitPriceNet;
+        }
+
         return $this->unitPrice;
     }
 
@@ -159,6 +171,18 @@ class BasketItem
     public function getTaxRate()
     {
         return $this->taxRate;
+    }
+
+    /**
+     * Enable or disable net mode.
+     * If enabled, the returned unit price
+     * will be the net price.
+     *
+     * @param bool $isNetMode
+     */
+    public function setNetMode($isNetMode)
+    {
+        $this->isNetMode = $isNetMode;
     }
 
 }

--- a/Controllers/Frontend/Mollie.php
+++ b/Controllers/Frontend/Mollie.php
@@ -624,6 +624,14 @@ class Shopware_Controllers_Frontend_Mollie extends AbstractPaymentController
             # if we have shipping costs
             # then convert them to a transaction item too
             if ($shippingItem->getUnitPrice() > 0) {
+
+                # our articles are all correctly set to gross or net
+                # price depending on the shop setting.
+                # but shipping will always return gross AND net in different fields.
+                # our transaction builder will automatically convert NET to GROSS
+                # so we need to make sure to set the net price manually in that case.
+                $shippingItem->setNetMode($taxMode->isNetOrder());
+
                 $transactionItem = $transactionBuilder->buildTransactionItem($transaction, $shippingItem);
                 $transactionItems->add($transactionItem);
             }

--- a/Tests/Components/TransactionBuilder/Models/BasketItemTest.php
+++ b/Tests/Components/TransactionBuilder/Models/BasketItemTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace MollieShopware\Tests\Components\TransactionBuilder\Models;
+
+use MollieShopware\Components\TransactionBuilder\Models\BasketItem;
+use PHPUnit\Framework\TestCase;
+
+class BasketItemTest extends TestCase
+{
+
+    /**
+     * This test verifies that we get the gross price
+     * if we access it, and our NET mode is off.
+     *
+     * @covers \MollieShopware\Components\TransactionBuilder\Models\BasketItem::setNetMode
+     * @covers \MollieShopware\Components\TransactionBuilder\Models\BasketItem::getUnitPrice
+     */
+    public function testUnitPriceNetModeOFF()
+    {
+        $shipping = new BasketItem(0, 0, '', 0, 0, '', 16.6, 10, 1, 16);
+        $shipping->setNetMode(false);
+
+        $this->assertEquals(16.6, $shipping->getUnitPrice());
+    }
+
+    /**
+     * This test verifies that we get the unit price
+     * if we access it, and our NET mode is on.
+     *
+     * @covers \MollieShopware\Components\TransactionBuilder\Models\BasketItem::setNetMode
+     * @covers \MollieShopware\Components\TransactionBuilder\Models\BasketItem::getUnitPrice
+     */
+    public function testUnitPriceNetModeON()
+    {
+        $shipping = new BasketItem(0, 0, '', 0, 0, '', 16.6, 10, 1, 16);
+        $shipping->setNetMode(true);
+
+        $this->assertEquals(10.0, $shipping->getUnitPrice());
+    }
+
+}


### PR DESCRIPTION
shippings have been converted to gross twice 

articles have either gross or net price in UnitPrice
shippings have ALWAYS gross in there
so we need to change the mode in that to be like "articles" for the transaction item builder