### PR TITLE
MOL-65: Show test mode information in storefront

### DIFF
--- a/Components/ApplePayDirect/Services/ApplePayFormatter.php
+++ b/Components/ApplePayDirect/Services/ApplePayFormatter.php
@@ -12,6 +12,8 @@ use Shopware\Models\Shop\Shop;
 class ApplePayFormatter
 {
 
+    const TEST_SUFFIX = "(Test Mode)";
+
     /**
      * this is the default snippet namespace for our
      * mollie apple pay direct translation.
@@ -26,14 +28,13 @@ class ApplePayFormatter
 
     /**
      * ApplePayFormatter constructor.
-     *
      * @param $snippets
      */
     public function __construct($snippets)
     {
         $this->snippets = $snippets->getNamespace(self::SNIPPET_NS);
     }
-    
+
     /**
      * @param array $method
      * @param $shippingCosts
@@ -52,15 +53,22 @@ class ApplePayFormatter
     /**
      * @param ApplePayCart $cart
      * @param Shop $shop
+     * @param bool $isTestMode
      * @return array
      */
-    public function formatCart(ApplePayCart $cart, Shop $shop)
+    public function formatCart(ApplePayCart $cart, Shop $shop, $isTestMode)
     {
+        $shopName = $shop->getName();
+
+        if ($isTestMode) {
+            $shopName .= ' ' . self::TEST_SUFFIX;
+        }
+
         # -----------------------------------------------------
         # INITIAL DATA
         # -----------------------------------------------------
         $data = array(
-            'label' => $shop->getName(),
+            'label' => $shopName,
             'amount' => $this->prepareFloat($cart->getAmount()),
             'items' => array(),
         );
@@ -102,7 +110,7 @@ class ApplePayFormatter
         # TOTAL DATA
         # -----------------------------------------------------
         $data['total'] = array(
-            'label' => $shop->getName(),
+            'label' => $shopName,
             'amount' => $this->prepareFloat($cart->getAmount()),
             'type' => 'final',
         );

--- a/Controllers/Frontend/MollieApplePayDirect.php
+++ b/Controllers/Frontend/MollieApplePayDirect.php
@@ -8,6 +8,7 @@ use MollieShopware\Components\ApplePayDirect\Models\UserData\UserData;
 use MollieShopware\Components\ApplePayDirect\Services\ApplePayFormatter;
 use MollieShopware\Components\ApplePayDirect\Services\ApplePayPaymentMethod;
 use MollieShopware\Components\BasketSnapshot\BasketSnapshot;
+use MollieShopware\Components\Config;
 use MollieShopware\Components\Country\CountryIsoParser;
 use MollieShopware\Components\Order\OrderAddress;
 use MollieShopware\Components\Order\OrderSession;
@@ -73,6 +74,11 @@ class Shopware_Controllers_Frontend_MollieApplePayDirect extends Shopware_Contro
      */
     private $basketSnapshot;
 
+    /**
+     * @var Config
+     */
+    private $config;
+
 
     /**
      * @return string[]
@@ -104,6 +110,8 @@ class Shopware_Controllers_Frontend_MollieApplePayDirect extends Shopware_Contro
         $this->orderSession = Shopware()->Container()->get('mollie_shopware.components.order_session');
         $this->account = Shopware()->Container()->get('mollie_shopware.components.account.account');
         $this->basketSnapshot = Shopware()->Container()->get('mollie_shopware.components.basket_snapshot.basket_snapshot');
+
+        $this->config = Shopware()->Container()->get('mollie_shopware.config');
 
         $this->applePayPaymentMethod = Shopware()->Container()->get('mollie_shopware.components.apple_pay_direct.services.payment_method');
         $this->applePayFormatter = Shopware()->Container()->get('mollie_shopware.components.apple_pay_direct.services.formatter');
@@ -219,7 +227,11 @@ class Shopware_Controllers_Frontend_MollieApplePayDirect extends Shopware_Contro
 
 
             $cart = $this->handlerApplePay->buildApplePayCart();
-            $formattedCart = $this->applePayFormatter->formatCart($cart, Shopware()->Shop());
+            $formattedCart = $this->applePayFormatter->formatCart(
+                $cart,
+                Shopware()->Shop(),
+                $this->config->isTestmodeActive()
+            );
 
 
             $data = array(
@@ -280,7 +292,11 @@ class Shopware_Controllers_Frontend_MollieApplePayDirect extends Shopware_Contro
             }
 
             $cart = $this->handlerApplePay->buildApplePayCart();
-            $formattedCart = $this->applePayFormatter->formatCart($cart, Shopware()->Shop());
+            $formattedCart = $this->applePayFormatter->formatCart(
+                $cart,
+                Shopware()->Shop(),
+                $this->config->isTestmodeActive()
+            );
 
             $data = array(
                 'success' => true,

--- a/MollieShopware.php
+++ b/MollieShopware.php
@@ -32,7 +32,9 @@ class MollieShopware extends Plugin
 
     const PLUGIN_VERSION = '1.6.6';
 
+    const PAYMENT_PREFIX = 'mollie_';
 
+    
     /**
      * Return Shopware events subscribed to
      */

--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -8,6 +8,7 @@
         <import resource="services/logger.xml"/>
         <import resource="services/applepay_direct.xml"/>
         <import resource="services/components.xml"/>
+        <import resource="services/subscriber.xml"/>
     </imports>
 
     <services>

--- a/Resources/services/subscriber.xml
+++ b/Resources/services/subscriber.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <service id="mollie_shopware.subscriber.test_mode_subscriber" class="MollieShopware\Subscriber\TestModeSubscriber">
+            <tag name="shopware.event_subscriber"/>
+        </service>
+
+    </services>
+</container>

--- a/Subscriber/TestModeSubscriber.php
+++ b/Subscriber/TestModeSubscriber.php
@@ -1,0 +1,177 @@
+<?php
+
+
+namespace MollieShopware\Subscriber;
+
+
+use Enlight\Event\SubscriberInterface;
+use Enlight_Event_EventArgs;
+use Enlight_View;
+use MollieShopware\Components\Config;
+use MollieShopware\MollieShopware;
+
+class TestModeSubscriber implements SubscriberInterface
+{
+
+    const TEST_SUFFIX = "(Mollie Test Mode)";
+
+    /**
+     * @return array|string[]
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            'Enlight_Controller_Action_PostDispatch_Frontend_Checkout' => 'onFrontendPostDispatch',
+            'Enlight_Controller_Action_PostDispatch_Frontend_Account' => 'onFrontendPostDispatch',
+        ];
+    }
+
+
+    /**
+     * @param Enlight_Event_EventArgs $args
+     */
+    public function onFrontendPostDispatch(Enlight_Event_EventArgs $args)
+    {
+        /** @var Config $config */
+        $config = Shopware()->Container()->get('mollie_shopware.config');
+
+        if ($config->isTestmodeActive() === false) {
+            return;
+        }
+
+        /** @var Enlight_View $view */
+        $view = $args->getSubject()->View();
+
+        $ctrl = $args->getRequest()->getControllerName();
+        $action = $args->getRequest()->getActionName();
+
+        $prefix = MollieShopware::PAYMENT_PREFIX;
+
+        if ($ctrl === 'account' && $action === 'payment') {
+            $this->onAccountPaymentSelectionPostDispatch($view, $prefix);
+            return;
+        }
+
+        if ($ctrl === 'checkout' && $action === 'shippingPayment') {
+            $this->onCheckoutPaymentSelectionPostDispatch($view, $prefix);
+            return;
+        }
+
+        if ($ctrl === 'checkout' && $action === 'confirm') {
+            $this->onCheckoutConfirmPostDispatch($view, $prefix);
+            return;
+        }
+
+        if ($ctrl === 'checkout' && $action === 'finish') {
+            $this->onCheckoutFinishedPostDispatch($view, $prefix);
+            return;
+        }
+    }
+
+
+    /**
+     * @param Enlight_View $view
+     * @param $prefix
+     */
+    public function onAccountPaymentSelectionPostDispatch(Enlight_View $view, $prefix)
+    {
+        $payments = $view->getAssign('sPaymentMeans');
+
+        if ($payments === null) {
+            return;
+        }
+
+        foreach ($payments as &$payment) {
+            $payment = $this->replacePaymentMeanTitle($payment, $prefix);
+        }
+
+        $view->assign('sPaymentMeans', $payments);
+    }
+
+    /**
+     * @param Enlight_View $view
+     * @param $prefix
+     */
+    public function onCheckoutPaymentSelectionPostDispatch(Enlight_View $view, $prefix)
+    {
+        $payments = $view->getAssign('sPayments');
+
+        if ($payments === null) {
+            return;
+        }
+
+        foreach ($payments as &$payment) {
+            $payment = $this->replacePaymentMeanTitle($payment, $prefix);
+        }
+
+        $view->assign('sPayments', $payments);
+    }
+
+    /**
+     * @param Enlight_View $view
+     * @param $prefix
+     */
+    public function onCheckoutConfirmPostDispatch(Enlight_View $view, $prefix)
+    {
+        $sUserData = $view->getAssign('sUserData');
+
+        if (!isset($sUserData['additional'])) {
+            return;
+        }
+
+        if (!isset($sUserData['additional']['payment'])) {
+            return;
+        }
+
+        if (!isset($sUserData['additional']['payment']['name'])) {
+            return;
+        }
+
+        # check if the name contains mollie_
+        if (strpos($sUserData['additional']['payment']['name'], $prefix) === false) {
+            return;
+        }
+
+        $sUserData['additional']['payment']['description'] .= ' ' . self::TEST_SUFFIX;
+
+        $view->assign('sUserData', $sUserData);
+    }
+
+    /**
+     * @param Enlight_View $view
+     * @param $prefix
+     */
+    public function onCheckoutFinishedPostDispatch(Enlight_View $view, $prefix)
+    {
+        $payment = $view->getAssign('sPayment');
+
+        $payment = $this->replacePaymentMeanTitle($payment, $prefix);
+
+        $view->assign('sPayment', $payment);
+    }
+
+    /**
+     * @param $paymentMean
+     * @param $prefix
+     * @return mixed
+     */
+    private function replacePaymentMeanTitle($paymentMean, $prefix)
+    {
+        if (!isset($paymentMean['name'])) {
+            return $paymentMean;
+        }
+
+        if (!isset($paymentMean['description'])) {
+            return $paymentMean;
+        }
+
+        if (strpos($paymentMean['name'], $prefix) === false) {
+            return $paymentMean;
+        }
+
+        $paymentMean['description'] = $paymentMean['description'] . ' ' . self::TEST_SUFFIX;
+
+        return $paymentMean;
+    }
+
+}


### PR DESCRIPTION
mollie payment methods will now get a TEST_MODE suffix in test mode

a test subscriber handles account, confirm, payment, and finish
and adds Mollie Test Mode only to mollie payments

apple pay will show Test Mode also in the payment sheet as shop name
(without mollie, because its clear what it is)
