### PR TITLE
MOL-76: Shipping Cost Improvement

### DIFF
--- a/Components/Services/OrderService.php
+++ b/Components/Services/OrderService.php
@@ -284,4 +284,31 @@ class OrderService
 
         return $items;
     }
+
+    public function getOrderBySessionId(string $sessionId)
+    {
+        $order = null;
+
+        try {
+            /** @var \Shopware\Models\Order\Repository $orderRepo */
+            $orderRepo = $this->modelManager->getRepository(
+                \Shopware\Models\Order\Order::class
+            );
+
+            /** @var \Shopware\Models\Order\Order $order */
+            $order = $orderRepo->findOneBy([
+                'temporaryId' => $sessionId
+            ]);
+        }
+        catch (\Exception $ex) {
+            $this->logger->error(
+                'Error when loading order by session ID: ' . $sessionId,
+                array(
+                    'error' => $ex->getMessage(),
+                )
+            );
+        }
+
+        return $order;
+    }
 }

--- a/Components/Shipping/Providers/CartShippingCostsProvider.php
+++ b/Components/Shipping/Providers/CartShippingCostsProvider.php
@@ -2,18 +2,32 @@
 
 namespace MollieShopware\Components\Shipping\Providers;
 
-use MollieShopware\Components\Shipping\ShippingCostsProviderInterface;
+use MollieShopware\Components\Services\OrderService;
 use MollieShopware\Components\Shipping\Models\ShippingCosts;
+use MollieShopware\Components\Shipping\ShippingCostsProviderInterface;
+use MollieShopware\Exceptions\OrderNotFoundBySessionIdException;
+use Shopware\Models\Order\Order;
 
 class CartShippingCostsProvider implements ShippingCostsProviderInterface
 {
+    /** @var OrderService */
+    private $orderService;
+
+    /**
+     * @param OrderService $orderService
+     */
+    public function __construct(OrderService $orderService)
+    {
+        $this->orderService = $orderService;
+    }
 
     /**
      * @return ShippingCosts
+     * @throws OrderNotFoundBySessionIdException
      */
     public function getShippingCosts()
     {
-        $shippingCosts = Shopware()->Modules()->Admin()->sGetPremiumShippingcosts();
+        $shippingCosts = $this->getInvoiceShippingCosts();
 
         $unitPrice = 0;
         $unitPriceNet = 0;
@@ -30,6 +44,52 @@ class CartShippingCostsProvider implements ShippingCostsProviderInterface
             $unitPriceNet,
             $taxRate
         );
+    }
+
+    /**
+     * @return array|null
+     * @throws OrderNotFoundBySessionIdException
+     */
+    private function getInvoiceShippingCosts()
+    {
+        $sessionId = Shopware()->Session()->offsetGet('sessionId');
+
+        /** @var Order $order */
+        $order = $this->orderService->getOrderBySessionId($sessionId);
+
+        if ($order === null) {
+            throw new OrderNotFoundBySessionIdException($sessionId);
+        }
+
+        $brutto = round($order->getInvoiceShipping(), 2);
+        $netto = round($order->getInvoiceShippingNet(), 2);
+        $taxRate = $this->getTaxRate($order);
+
+        return [
+            'brutto' => $brutto,
+            'netto' => $netto,
+            'tax' => $taxRate
+        ];
+    }
+
+    /**
+     * @param Order $order
+     * @return float
+     */
+    private function getTaxRate(Order $order)
+    {
+        $taxRate = $order->getInvoiceShippingTaxRate();
+
+        if ($taxRate !== null) {
+            return $taxRate;
+        }
+
+        if ($order->getInvoiceShipping() === $order->getInvoiceShippingNet()) {
+            return 0.0;
+        }
+
+        // taxRate = (unroundedBrutto / unroundedNetto - 1) * 100, eg. (1.19 / 1 - 1) * 100 = 19.0
+        return (round($order->getInvoiceShipping() / $order->getInvoiceShippingNet(), 2) - 1) * 100;
     }
 
 }

--- a/Exceptions/OrderNotFoundBySessionIdException.php
+++ b/Exceptions/OrderNotFoundBySessionIdException.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace MollieShopware\Exceptions;
+
+
+/**
+ * @copyright 2021 dasistweb GmbH (https://www.dasistweb.de)
+ */
+class OrderNotFoundBySessionIdException extends \Exception
+{
+    /**
+     * @param $sessionId
+     */
+    public function __construct($sessionId)
+    {
+        parent::__construct('Order not found by sessionId: ' . $sessionId);
+    }
+}

--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -19,6 +19,7 @@
 
         <service id="mollie_shopware.components.shipping.provider.cart" class="MollieShopware\Components\Shipping\Providers\CartShippingCostsProvider"
                  public="false">
+            <argument type="service" id="mollie_shopware.order_service"/>
         </service>
 
         <service id="mollie_shopware.components.shipping" class="MollieShopware\Components\Shipping\Shipping">


### PR DESCRIPTION
The shipping costs have been calculated by the Admin shipping costs settings. As other plugins may add surcharges to the shipping costs this caused a difference between order total (in which the shipping surcharges were included) and the transmitted shipping costs because the calculated total and transmitted total were different.

The shipping costs are already saved calculated in the order, so use the order shipping costs for Mollie transaction.