### PR TITLE
MOL-117: Add anonymized payment token to logs

### DIFF
--- a/Services/TokenAnonymizer/TokenAnonymizer.php
+++ b/Services/TokenAnonymizer/TokenAnonymizer.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace MollieShopware\Services\TokenAnonymizer;
+
+class TokenAnonymizer
+{
+
+    /**
+     * @var string
+     */
+    private $placeholderSymbol;
+
+    /**
+     * @var int
+     */
+    private $placeholderCount;
+
+    /**
+     * @var int
+     */
+    private $maxLength;
+
+    /**
+     * @param string $placeholderSymbol
+     * @param int $placeholderCount
+     * @param int $maxLength
+     */
+    public function __construct(string $placeholderSymbol, int $placeholderCount, int $maxLength)
+    {
+        $this->placeholderSymbol = $placeholderSymbol;
+        $this->placeholderCount = $placeholderCount;
+        $this->maxLength = $maxLength;
+    }
+
+
+    /**
+     * @param $value
+     * @return false|string
+     */
+    public function anonymize($value)
+    {
+        if ($value === null) {
+            return '';
+        }
+
+        if (trim((string)$value) === '') {
+            return '';
+        }
+
+        if (strlen((string)$value) < $this->placeholderCount) {
+            return $value[0] . $this->getPlaceholder();
+        }
+
+        # only get the original value up to
+        # the allowed max length
+        $value = substr($value, 0, $this->maxLength);
+
+        # replace the last 4 characters with our placeholders
+        return substr($value, 0, -4) . $this->getPlaceholder();
+    }
+
+    /**
+     * @return string
+     */
+    private function getPlaceholder()
+    {
+        return str_repeat($this->placeholderSymbol, $this->placeholderCount);;
+    }
+
+}

--- a/Tests/Services/TokenAnonymizer/TokenAnonymizerTest.php
+++ b/Tests/Services/TokenAnonymizer/TokenAnonymizerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace MollieShopware\Tests\Services\TokenAnonymizer;
+
+use MollieShopware\Services\TokenAnonymizer\TokenAnonymizer;
+use PHPUnit\Framework\TestCase;
+
+
+class TokenAnonymizerTest extends TestCase
+{
+
+    /**
+     * This test verifies that we get an empty string
+     * if we have an invalid value that is just NULL.
+     *
+     * @covers \MollieShopware\Services\TokenAnonymizer\TokenAnonymizer
+     */
+    public function testAnonymizeNull()
+    {
+        $anonymizer = new TokenAnonymizer('*', 4, 100);
+        $anonymized = $anonymizer->anonymize(null);
+
+        $this->assertEquals('', $anonymized);
+    }
+
+    /**
+     * This test verifies that we get an empty string
+     * if we have an empty string..
+     *
+     * @covers \MollieShopware\Services\TokenAnonymizer\TokenAnonymizer
+     */
+    public function testAnonymizeEmpty()
+    {
+        $anonymizer = new TokenAnonymizer('*', 4, 100);
+        $anonymized = $anonymizer->anonymize('');
+
+        $this->assertEquals('', $anonymized);
+    }
+
+    /**
+     * This test verifies that we get an empty string
+     * if we have an invalid text with only spaces.
+     *
+     * @covers \MollieShopware\Services\TokenAnonymizer\TokenAnonymizer
+     */
+    public function testAnonymizeSpaces()
+    {
+        $anonymizer = new TokenAnonymizer('*', 4, 100);
+        $anonymized = $anonymizer->anonymize('   ');
+
+        $this->assertEquals('', $anonymized);
+    }
+
+    /**
+     * This test verifies we successfully anonymize the
+     * last 4 digits of our provided string value.
+     *
+     * @covers \MollieShopware\Services\TokenAnonymizer\TokenAnonymizer
+     */
+    public function testAnonymizeValue()
+    {
+        $anonymizer = new TokenAnonymizer('*', 4, 100);
+        $anonymized = $anonymizer->anonymize('123456789');
+
+        $this->assertEquals('12345****', $anonymized);
+    }
+
+    /**
+     * This test verifies that if we have less than the
+     * number of letters that should be anonymized, then we
+     * make sure to see the first letter, and then add wildcards
+     * with the number that we have provided.
+     *
+     * @covers \MollieShopware\Services\TokenAnonymizer\TokenAnonymizer
+     */
+    public function testAnonymizeValueIsTooShort()
+    {
+        $anonymizer = new TokenAnonymizer('*', 4, 100);
+        $anonymized = $anonymizer->anonymize('123');
+
+        $this->assertEquals('1****', $anonymized);
+    }
+
+    /**
+     * This test verifies that we correctly trim to the
+     * provided max length of the anonmyized string
+     *
+     * @covers \MollieShopware\Services\TokenAnonymizer\TokenAnonymizer
+     */
+    public function testMaxLength()
+    {
+        $anonymizer = new TokenAnonymizer('*', 4, 10);
+        $anonymized = $anonymizer->anonymize('01234567898765432');
+
+        $this->assertEquals('012345****', $anonymized);
+    }
+
+}

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,7 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "MollieShopware\\Components\\": "Components/",
-      "MollieShopware\\Models\\": "Models/",
-      "MollieShopware\\Tests\\": "Tests/"
+      "MollieShopware\\": "./"
     }
   }
 }


### PR DESCRIPTION
we sometimes have to debug i payment tokens are correctly used and existing
so it will now add tehese to the initial log entry

its of course anonymized and tested