### PR TITLE
MOL-100: Cleanup ordermailVariables and unset them

### DIFF
--- a/Controllers/Frontend/Mollie.php
+++ b/Controllers/Frontend/Mollie.php
@@ -222,6 +222,11 @@ class Shopware_Controllers_Frontend_Mollie extends AbstractPaymentController
             }
 
             $this->redirectBack(self::ERROR_PAYMENT_FAILED);
+
+        } finally {
+            if (!empty($transactionNumber)) {
+                $this->checkoutReturn->cleanupTransaction($transactionNumber);
+            }
         }
     }
 

--- a/Facades/FinishCheckout/FinishCheckoutFacade.php
+++ b/Facades/FinishCheckout/FinishCheckoutFacade.php
@@ -281,4 +281,23 @@ class FinishCheckoutFacade
         );
     }
 
+    /**
+     * @param $transactionNumber
+     * @throws \Doctrine\ORM\ORMException
+     * @throws \Doctrine\ORM\OptimisticLockException
+     */
+    public function cleanupTransaction($transactionNumber)
+    {
+        $transaction = $this->repoTransactions->find($transactionNumber);
+
+        if (!$transaction instanceof Transaction) {
+            return;
+        }
+
+        # Unset OrdermailVariables to prevent bloating transaction table
+        if ($transaction->getOrdermailVariables() !== null) {
+            $transaction->setOrdermailVariables(null);
+            $this->repoTransactions->save($transaction);
+        }
+    }
 }

--- a/Facades/FinishCheckout/Services/ConfirmationMail.php
+++ b/Facades/FinishCheckout/Services/ConfirmationMail.php
@@ -59,10 +59,6 @@ class ConfirmationMail
 
             $this->sOder->sendMail($variables);
         }
-
-        $transaction->setOrdermailVariables(null);
-
-        $this->repoTransaction->save($transaction);
     }
 
 }

--- a/MollieShopware.php
+++ b/MollieShopware.php
@@ -2,6 +2,7 @@
 
 namespace MollieShopware;
 
+use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Enlight_Template_Manager;
 use Exception;
@@ -262,6 +263,9 @@ class MollieShopware extends Plugin
 
         // add index to mol_sw_transactions if not exists
         $this->addIndexToTransactions();
+
+        // cleanup old transaction ordermail variables
+        $this->cleanOrdermailVariables();
 
         parent::activate($context);
     }
@@ -547,4 +551,11 @@ class MollieShopware extends Plugin
         }
     }
 
+    private function cleanOrdermailVariables()
+    {
+        /** @var Connection $connection */
+        $connection = $this->container->get('dbal_connection');
+
+        $connection->executeQuery('UPDATE mol_sw_transactions SET ordermail_variables = NULL');
+    }
 }


### PR DESCRIPTION
Move unsetting of ordermail variables to return action to also unset them when payment failed.

Add cleanup to activate action of plugin to clean up old ordermail variables.