### PR TITLE
MOL-126: Fix Apple Pay Direct for Orders API

### DIFF
--- a/Controllers/Frontend/Mollie.php
+++ b/Controllers/Frontend/Mollie.php
@@ -132,10 +132,10 @@ class Shopware_Controllers_Frontend_Mollie extends AbstractPaymentController
                 $currency
             );
 
-            if ($session->getCheckoutUrl() === PaymentService::CHECKOUT_URL_CC_NON3D_SECURE) {
-                # just finish our payment by redirecting
-                # to our return, such as if the user would have really
-                # visited the mollie payment form.
+            # some payment methods do not require a redirect to mollie.
+            # these are automatically approved and thus we
+            # have to immediately redirect to the return action.
+            if (!$session->isRedirectToMollieRequired()) {
                 $this->redirect(
                     [
                         'controller' => 'Mollie',

--- a/Facades/CheckoutSession/CheckoutSession.php
+++ b/Facades/CheckoutSession/CheckoutSession.php
@@ -10,6 +10,11 @@ class CheckoutSession
 {
 
     /**
+     * @var bool
+     */
+    private $redirectToMollieRequired;
+
+    /**
      * @var Transaction
      */
     private $transaction;
@@ -19,16 +24,25 @@ class CheckoutSession
      */
     private $checkoutUrl;
 
-
     /**
      * CheckoutSession constructor.
+     * @param bool $redirectToMollieRequired
      * @param Transaction $transaction
-     * @param $checkoutUrl
+     * @param string $checkoutUrl
      */
-    public function __construct(Transaction $transaction, $checkoutUrl)
+    public function __construct($redirectToMollieRequired, Transaction $transaction, $checkoutUrl)
     {
+        $this->redirectToMollieRequired = $redirectToMollieRequired;
         $this->transaction = $transaction;
         $this->checkoutUrl = $checkoutUrl;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isRedirectToMollieRequired()
+    {
+        return $this->redirectToMollieRequired;
     }
 
     /**

--- a/Facades/CheckoutSession/CheckoutSessionFacade.php
+++ b/Facades/CheckoutSession/CheckoutSessionFacade.php
@@ -247,7 +247,13 @@ class CheckoutSessionFacade
         # the user to for further payment steps.
         $checkoutUrl = $this->paymentService->startMollieSession($paymentShortName, $transaction);
 
+        # some payment methods are approved and
+        # paid immediately and don't require a redirect.
+        # so we just grab this information using our constant
+        $redirectRequired = ($checkoutUrl !== PaymentService::CHECKOUT_URL_NO_REDIRECT_TO_MOLLIE_REQUIRED);
+
         return new CheckoutSession(
+            $redirectRequired,
             $transaction,
             $checkoutUrl
         );


### PR DESCRIPTION
apple pay direct does now also NOT have a checkout url which was missing in  the orders api

also renamed the non-3d-secure to be more generic and tell what it actually does
"redirect to mollie required" yes/no

