### PR TITLE
MOL-123: Cancel Order and reset Quantity after basket restore

### DIFF
--- a/Components/Order/OrderCancellation.php
+++ b/Components/Order/OrderCancellation.php
@@ -97,11 +97,15 @@ class OrderCancellation
             return;
         }
 
+        # restore the cart, otherwise it would be empty
+
+        # it's important to restore the order before the placed order is cancelled
+        # otherwise the original quantity of the line items can't be restored
+        $this->restoreCartFromOrder($swOrder);
+
         # make sure we have all status data cancelled as expected
         $this->cancelPlacedOrder($swOrder);
 
-        # restore the cart, otherwise it would be empty
-        $this->restoreCartFromOrder($swOrder);
     }
 
     /**


### PR DESCRIPTION
After a failed payment the original order has been canceled first and the quantity has been set to 0, then the basket has been restored and so it couldn't load the original quantity. 
Changed the order of cart restore and order cancellation.