### PR TITLE
MOL-124: Allow Invoice and Shipping Reset independent from Stock Reset

### DIFF
--- a/Components/Order/OrderCancellation.php
+++ b/Components/Order/OrderCancellation.php
@@ -129,6 +129,10 @@ class OrderCancellation
             if ($this->config->autoResetStock()) {
                 $this->paymentService->resetStock($order);
             }
+
+            if ($this->config->resetInvoiceAndShipping()){
+                $this->paymentService->resetInvoiceAndShipping($order);
+            }
         }
     }
 

--- a/Components/Services/PaymentService.php
+++ b/Components/Services/PaymentService.php
@@ -718,6 +718,10 @@ class PaymentService
                 if ($this->config->autoResetStock()) {
                     $this->resetStock($order);
                 }
+
+                if ($this->config->resetInvoiceAndShipping()){
+                    $this->resetInvoiceAndShipping($order);
+                }
             }
 
             if ($returnResult) {
@@ -745,6 +749,10 @@ class PaymentService
 
                 if ($this->config->autoResetStock()) {
                     $this->resetStock($order);
+                }
+
+                if ($this->config->resetInvoiceAndShipping()) {
+                    $this->resetInvoiceAndShipping($order);
                 }
             }
 
@@ -889,22 +897,31 @@ class PaymentService
      */
     public function resetStock(Order $order)
     {
-        if ($this->config->autoResetStock()) {
-            // Cancel failed orders
-            /** @var \MollieShopware\Components\Services\BasketService $basketService */
-            $basketService = Shopware()->Container()->get('mollie_shopware.basket_service');
-            // Reset order quantity
-            foreach ($order->getDetails() as $orderDetail) {
-                $basketService->resetOrderDetailQuantity($orderDetail);
-            }
-            // Reset shipping and invoice amount
-            if ($this->config->resetInvoiceAndShipping()) {
-                $order->setInvoiceShipping(0);
-                $order->setInvoiceShippingNet(0);
-                $order->setInvoiceAmount(0);
-                $order->setInvoiceAmountNet(0);
-            }
+        /** @var \MollieShopware\Components\Services\BasketService $basketService */
+        $basketService = Shopware()->Container()->get('mollie_shopware.basket_service');
+        // Reset order quantity
+        foreach ($order->getDetails() as $orderDetail) {
+            $basketService->resetOrderDetailQuantity($orderDetail);
         }
+
+        // Store order
+        Shopware()->Models()->persist($order);
+        Shopware()->Models()->flush($order);
+    }
+
+    /**
+     * Reset invoice and shipping on an order
+     *
+     * @param Order $order
+     * @throws \Exception
+     */
+    public function resetInvoiceAndShipping(Order $order)
+    {
+        // Reset shipping and invoice amount
+        $order->setInvoiceShipping(0);
+        $order->setInvoiceShippingNet(0);
+        $order->setInvoiceAmount(0);
+        $order->setInvoiceAmountNet(0);
 
         // Store order
         Shopware()->Models()->persist($order);


### PR DESCRIPTION
Invoice and Shipping Reset has only been allowed when Stock Reset was enabled. This hasn't been mentioned in Config and also it could be useful to allow it when Stock Reset is disabled. So made it independent.