### PR TITLE
MOL-125: Skip Webhooks that come in too fast

### DIFF
--- a/Controllers/Frontend/Mollie.php
+++ b/Controllers/Frontend/Mollie.php
@@ -192,7 +192,7 @@ class Shopware_Controllers_Frontend_Mollie extends AbstractPaymentController
                 throw new Exception('Missing Transaction Number');
             }
 
-            $this->logger->debug('Returning from Mollie for Transaction ' . $transactionNumber);
+            $this->logger->debug('User returning from Mollie for Transaction ' . $transactionNumber);
 
             $checkoutData = $this->checkoutReturn->finishTransaction($transactionNumber);
 
@@ -241,14 +241,18 @@ class Shopware_Controllers_Frontend_Mollie extends AbstractPaymentController
 
             $this->loadServices();
 
-            /** @var string $transactionNumber */
-            $transactionNumber = $this->Request()->getParam('transactionNumber');
+            /** @var string $transactionID */
+            $transactionID = $this->Request()->getParam('transactionNumber', '');
 
-            if (empty($transactionNumber)) {
+            if (empty($transactionID)) {
                 throw new \Exception('No transaction number provided!');
             }
 
-            $this->notifications->onNotify($transactionNumber);
+            /** @var string $paymentID */
+            $paymentID = $this->Request()->getParam('id', '');
+
+
+            $this->notifications->onNotify($transactionID, $paymentID);
 
             $data = array(
                 'success' => true,

--- a/Facades/CheckoutSession/CheckoutSessionFacade.php
+++ b/Facades/CheckoutSession/CheckoutSessionFacade.php
@@ -226,8 +226,6 @@ class CheckoutSessionFacade
                 throw new \Exception('The order with order number ' . $orderNumber . ' could not be found');
             }
 
-            $this->logger->debug('Created Order: ' . $orderNumber . ' for Transaction: ' . $transaction->getId());
-
             # now that we have the order, we need to remember it
             # this is required to restore the basket from that order in case of
             # any additional failures below. otherwise the cart is empty because


### PR DESCRIPTION
some webhooks are way too fast

the only way to recognize this at the moment is to see if there would be a POST variable "id"
and our matching id in the database is still empty
then just skip

using the sent id could be done in the future (added a TODO)

also updated some logs for better webhooks and logging