### PR TITLE
MOL-122: Apple Pay Direct Session was not completed

### DIFF
--- a/Resources/views/frontend/_public/src/js/applepay-direct.js
+++ b/Resources/views/frontend/_public/src/js/applepay-direct.js
@@ -203,6 +203,11 @@ function initApplePay() {
         session.onpaymentauthorized = function (e) {
             let paymentToken = e.payment.token;
             paymentToken = JSON.stringify(paymentToken);
+
+            // complete the session and notify the
+            // devices and the system that everything worked
+            session.completePayment(ApplePaySession.STATUS_SUCCESS);
+
             // now finish our payment by filling a form
             // and submitting it along with our payment token
             finishPayment(button.dataset.checkouturl, paymentToken, e.payment);


### PR DESCRIPTION
the session was not completed
thus it did not always work as expected the second time (it hanged)

and the feedback on iPhone or watch devices was sometimes "failed"