### PR TITLE
[MOL-104] Make applepay integration IE11 compatible.

### DIFF
--- a/Resources/views/frontend/_public/src/js/applepay-direct.js
+++ b/Resources/views/frontend/_public/src/js/applepay-direct.js
@@ -17,15 +17,15 @@ function initApplePay() {
         // we need our wrapping div layer
         // because that one will also be hidden to avoid any existing margins
         // if no apple pay should be displayed at all
-        const divsApplePay = document.querySelectorAll(applePayDivSelector);
+        var divsApplePay = document.querySelectorAll(applePayDivSelector);
 
         if (!window.ApplePaySession || !window.ApplePaySession.canMakePayments()) {
             // hide our wrapping apple pay div
             // to avoid any wrong margins if no apple pay is displayed
             if (divsApplePay) {
-                divsApplePay.forEach(function (div) {
-                    div.style.display = "none";
-                });
+                for (var i = 0; i < divsApplePay.length; i++) {
+                    divsApplePay[i].style.display = "none";
+                }
             }
             return;
         }
@@ -56,9 +56,9 @@ function initApplePay() {
      */
     function onButtonClick(event) {
 
-        const button = event.target;
+        var button = event.target;
 
-        const session = createApplePaySession(
+        var session = createApplePaySession(
             button.dataset.label,
             button.dataset.amount,
             button.dataset.country,
@@ -73,11 +73,11 @@ function initApplePay() {
         if (button.dataset.addproducturl) {
 
             // our fallback is quantity 1
-            let qty = 1;
+            var qty = 1;
 
             // if we have our sQuantity dropdown, use
             // that quantity when adding the product
-            const comboQuantity = document.getElementById('sQuantity');
+            var comboQuantity = document.getElementById('sQuantity');
             if (comboQuantity) {
                 qty = comboQuantity.value;
             }
@@ -201,7 +201,7 @@ function initApplePay() {
          * @param e
          */
         session.onpaymentauthorized = function (e) {
-            let paymentToken = e.payment.token;
+            var paymentToken = e.payment.token;
             paymentToken = JSON.stringify(paymentToken);
             // now finish our payment by filling a form
             // and submitting it along with our payment token
@@ -220,7 +220,7 @@ function initApplePay() {
      * @returns {ApplePaySession}
      */
     function createApplePaySession(label, amount, country, currency) {
-        const request = {
+        var request = {
             countryCode: country,
             currencyCode: currency,
             requiredShippingContactFields: [

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     <label lang="de">Mollie</label>
     <label lang="nl">Mollie</label>
 
-    <version>1.6.8</version>
+    <version>1.6.7</version>
     <copyright>(c) Mollie B.V.</copyright>
     <license>MIT</license>
     <author>Mollie B.V.</author>
@@ -41,7 +41,7 @@
         https://github.com/mollie/Shopware/wiki
     </description>
 
-    <changelog version="1.6.8">
+    <changelog version="unreleased">
         <changes lang="de">
             - Die Apple Pay Integration verursacht nun keine Fehler mehr im Internet Explorer.
         </changes>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     <label lang="de">Mollie</label>
     <label lang="nl">Mollie</label>
 
-    <version>1.6.7</version>
+    <version>1.6.8</version>
     <copyright>(c) Mollie B.V.</copyright>
     <license>MIT</license>
     <author>Mollie B.V.</author>
@@ -41,6 +41,14 @@
         https://github.com/mollie/Shopware/wiki
     </description>
 
+    <changelog version="1.6.8">
+        <changes lang="de">
+            - Die Apple Pay Integration verursacht nun keine Fehler mehr im Internet Explorer.
+        </changes>
+        <changes lang="en">
+            - The apple pay integration does not cause any errors in the internet explorer anymore.
+        </changes>
+    </changelog>
 
     <changelog version="1.6.7">
         <changes lang="de">


### PR DESCRIPTION
The Apple pay integration causes issues when run in the internet explorer. These problems are caused by the not-existing EcmaScript compatability and are fixed by these changes