### PR TITLE
NTR: add missing status mapping for failed

### DIFF
--- a/Components/Helpers/MollieStatusConverter.php
+++ b/Components/Helpers/MollieStatusConverter.php
@@ -66,6 +66,10 @@ class MollieStatusConverter
                 $targetStatus = PaymentStatus::MOLLIE_PAYMENT_COMPLETED;
             }
 
+            if ($paymentsResult[PaymentStatus::MOLLIE_PAYMENT_FAILED] == $paymentsResult['total']) {
+                $targetStatus = PaymentStatus::MOLLIE_PAYMENT_FAILED;
+            }
+
         } else {
 
             if ($order->isPaid()) {


### PR DESCRIPTION
just found a bug
i dont know if that mapping was always missing :) but now it shows an error which might be misleading