### PR TITLE
Mol 129/fallback shipping costs for direct payments

### DIFF
--- a/Components/Services/OrderService.php
+++ b/Components/Services/OrderService.php
@@ -284,4 +284,31 @@ class OrderService
 
         return $items;
     }
+
+    public function getOrderBySessionId(string $sessionId)
+    {
+        $order = null;
+
+        try {
+            /** @var \Shopware\Models\Order\Repository $orderRepo */
+            $orderRepo = $this->modelManager->getRepository(
+                \Shopware\Models\Order\Order::class
+            );
+
+            /** @var \Shopware\Models\Order\Order $order */
+            $order = $orderRepo->findOneBy([
+                'temporaryId' => $sessionId
+            ]);
+        }
+        catch (\Exception $ex) {
+            $this->logger->error(
+                'Error when loading order by session ID: ' . $sessionId,
+                array(
+                    'error' => $ex->getMessage(),
+                )
+            );
+        }
+
+        return $order;
+    }
 }

--- a/Components/Shipping/Providers/CartShippingCostsProvider.php
+++ b/Components/Shipping/Providers/CartShippingCostsProvider.php
@@ -2,18 +2,32 @@
 
 namespace MollieShopware\Components\Shipping\Providers;
 
-use MollieShopware\Components\Shipping\ShippingCostsProviderInterface;
+use MollieShopware\Components\Services\OrderService;
 use MollieShopware\Components\Shipping\Models\ShippingCosts;
+use MollieShopware\Components\Shipping\ShippingCostsProviderInterface;
+use MollieShopware\Exceptions\OrderNotFoundBySessionIdException;
+use Shopware\Models\Order\Order;
 
 class CartShippingCostsProvider implements ShippingCostsProviderInterface
 {
+    /** @var OrderService */
+    private $orderService;
+
+    /**
+     * @param OrderService $orderService
+     */
+    public function __construct(OrderService $orderService)
+    {
+        $this->orderService = $orderService;
+    }
 
     /**
      * @return ShippingCosts
+     * @throws OrderNotFoundBySessionIdException
      */
     public function getShippingCosts()
     {
-        $shippingCosts = Shopware()->Modules()->Admin()->sGetPremiumShippingcosts();
+        $shippingCosts = $this->getInvoiceShippingCosts();
 
         $unitPrice = 0;
         $unitPriceNet = 0;
@@ -30,6 +44,52 @@ class CartShippingCostsProvider implements ShippingCostsProviderInterface
             $unitPriceNet,
             $taxRate
         );
+    }
+
+    /**
+     * @return array|null
+     * @throws OrderNotFoundBySessionIdException
+     */
+    private function getInvoiceShippingCosts()
+    {
+        $sessionId = Shopware()->Session()->offsetGet('sessionId');
+
+        /** @var Order $order */
+        $order = $this->orderService->getOrderBySessionId($sessionId);
+
+        if ($order === null) {
+            throw new OrderNotFoundBySessionIdException($sessionId);
+        }
+
+        $brutto = round($order->getInvoiceShipping(), 2);
+        $netto = round($order->getInvoiceShippingNet(), 2);
+        $taxRate = $this->getTaxRate($order);
+
+        return [
+            'brutto' => $brutto,
+            'netto' => $netto,
+            'tax' => $taxRate
+        ];
+    }
+
+    /**
+     * @param Order $order
+     * @return float
+     */
+    private function getTaxRate(Order $order)
+    {
+        $taxRate = $order->getInvoiceShippingTaxRate();
+
+        if ($taxRate !== null) {
+            return $taxRate;
+        }
+
+        if ($order->getInvoiceShipping() === $order->getInvoiceShippingNet()) {
+            return 0.0;
+        }
+
+        // taxRate = (unroundedBrutto / unroundedNetto - 1) * 100, eg. (1.19 / 1 - 1) * 100 = 19.0
+        return (round($order->getInvoiceShipping() / $order->getInvoiceShippingNet(), 2) - 1) * 100;
     }
 
 }

--- a/Components/Shipping/Providers/CartShippingCostsProvider.php
+++ b/Components/Shipping/Providers/CartShippingCostsProvider.php
@@ -27,7 +27,15 @@ class CartShippingCostsProvider implements ShippingCostsProviderInterface
      */
     public function getShippingCosts()
     {
-        $shippingCosts = $this->getInvoiceShippingCosts();
+        try {
+            // Use the already in order calculated shipping costs if they exist
+            $shippingCosts = $this->getInvoiceShippingCosts();
+        } catch (OrderNotFoundBySessionIdException $ex) {
+            // If order not found by session ID use backend shipping costs configuration.
+            // This is an important Fallback for Direct Payment Methods which don't create
+            // orders in database before they redirect to the external direct checkout
+            $shippingCosts = Shopware()->Modules()->Admin()->sGetPremiumShippingcosts();
+        }
 
         $unitPrice = 0;
         $unitPriceNet = 0;

--- a/Exceptions/OrderNotFoundBySessionIdException.php
+++ b/Exceptions/OrderNotFoundBySessionIdException.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace MollieShopware\Exceptions;
+
+
+/**
+ * @copyright 2021 dasistweb GmbH (https://www.dasistweb.de)
+ */
+class OrderNotFoundBySessionIdException extends \Exception
+{
+    /**
+     * @param $sessionId
+     */
+    public function __construct($sessionId)
+    {
+        parent::__construct('Order not found by sessionId: ' . $sessionId);
+    }
+}

--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -19,6 +19,7 @@
 
         <service id="mollie_shopware.components.shipping.provider.cart" class="MollieShopware\Components\Shipping\Providers\CartShippingCostsProvider"
                  public="false">
+            <argument type="service" id="mollie_shopware.order_service"/>
         </service>
 
         <service id="mollie_shopware.components.shipping" class="MollieShopware\Components\Shipping\Shipping">


### PR DESCRIPTION
In case of Direct Payments a Fallback has been added which reads the ShippingCost Settings from Backend and calculates the Shipping Costs.

This PR is based on MOL-76