### PR TITLE
MOL-68: Prevent Apple Pay Direct on confirm page

### DIFF
--- a/Components/Constants/ShopwarePaymentMethod.php
+++ b/Components/Constants/ShopwarePaymentMethod.php
@@ -2,9 +2,19 @@
 
 namespace MollieShopware\Components\Constants;
 
+use MollieShopware\MollieShopware;
+
 class ShopwarePaymentMethod
 {
 
-    const APPLEPAYDIRECT = 'mollie_' . PaymentMethod::APPLEPAY_DIRECT;
+    /**
+     *
+     */
+    const APPLEPAYDIRECT = MollieShopware::PAYMENT_PREFIX . PaymentMethod::APPLEPAY_DIRECT;
+
+    /**
+     *
+     */
+    const APPLEPAY = MollieShopware::PAYMENT_PREFIX . PaymentMethod::APPLE_PAY;
 
 }


### PR DESCRIPTION
if the payment fails, the confirm page is visible,
in that case we have to ensure to switch from apple pay direct to apple pay (normal payment method)

this also works if you have a successfull apple pay direct payment as last payment
and do another order with normal workflow. then apple pay will be preselected