### PR TITLE
MOL-135: avoid duplicate orders due to multiple return-url calls

### DIFF
--- a/Components/Order/ShopwareOrderBuilder.php
+++ b/Components/Order/ShopwareOrderBuilder.php
@@ -2,6 +2,8 @@
 
 namespace MollieShopware\Components\Order;
 
+use MollieShopware\Components\Services\OrderService;
+use MollieShopware\Exceptions\OrderNotFoundException;
 use MollieShopware\Models\Transaction;
 use Psr\Log\LoggerInterface;
 use Shopware\Models\Order\Status;
@@ -16,18 +18,26 @@ class ShopwareOrderBuilder
     private $controller;
 
     /**
+     * @var OrderService
+     */
+    private $orderService;
+
+    /**
      * @var LoggerInterface
      */
     private $logger;
 
 
     /**
+     * ShopwareOrderBuilder constructor.
      * @param Shopware_Controllers_Frontend_Payment $controller
+     * @param OrderService $orderService
      * @param LoggerInterface $logger
      */
-    public function __construct(Shopware_Controllers_Frontend_Payment $controller, LoggerInterface $logger)
+    public function __construct(Shopware_Controllers_Frontend_Payment $controller, OrderService $orderService, LoggerInterface $logger)
     {
         $this->controller = $controller;
+        $this->orderService = $orderService;
         $this->logger = $logger;
     }
 
@@ -52,24 +62,52 @@ class ShopwareOrderBuilder
     }
 
     /**
-     * @param Transaction $transaction
+     * @param $originalTransactionNumber
+     * @param $finalTransactionNumber
      * @param $sendPaymentStatusMail
+     * @param $basketSignature
      * @return false|int
      */
-    public function createOrderAfterPayment(Transaction $transaction, $sendPaymentStatusMail)
+    public function createOrderAfterPayment($originalTransactionNumber, $finalTransactionNumber, $sendPaymentStatusMail, $basketSignature)
     {
-        $transactionNumber = $transaction->getShopwareTransactionNumber();
+        $this->logger->debug('Create new Order after payment for Transaction ' . $originalTransactionNumber);
 
-        $this->logger->debug('Create new Order after payment for Transaction ' . $transactionNumber);
+        try {
 
-        $orderNumber = $this->controller->saveOrder(
-            $transactionNumber,
-            $transaction->getBasketSignature(),
+            # if the redirect URL is somehow called multiple times, or just "again" some time,
+            # we have to avoid that new orders get created.
+            # This is also solved by using the correct transactionNumber in the Shopware order.
+            # So Shopware itself will not create it multiple times - that's why we just continue with everything.
+            # Still, we want to log that the URL has been called again.
+            $existingOrder = $this->orderService->getOrderByTransactionId($finalTransactionNumber);
+
+            $this->logger->warning(
+                'Order is already existing for ' . $originalTransactionNumber . ' because Redirect-URL is called again!',
+                array(
+                    'error' => array(
+                        'reason' => 'This usually happens if the Mollie Redirect URL is called multiple times instead of just once! Then the order is only created the first time. It should not happen, but doesnt break anything!',
+                        'solution' => 'Please verify why the user got sent back from Mollie to your shop again!',
+                    ),
+                    'data' => array(
+                        'orderID' => $existingOrder->getId(),
+                        'orderNumber' => $existingOrder->getNumber(),
+                        'mollieTransaction' => $originalTransactionNumber,
+                        'shopwareTransaction' => $finalTransactionNumber,
+                    ),
+                )
+            );
+
+        } catch (OrderNotFoundException $ex) {
+            # if we have no order, we can continue
+            # by creating our new one
+        }
+
+        return $this->controller->saveOrder(
+            $finalTransactionNumber,
+            $basketSignature,
             Status::PAYMENT_STATE_OPEN,
             $sendPaymentStatusMail
         );
-
-        return $orderNumber;
     }
 
 }

--- a/Components/Services/OrderService.php
+++ b/Components/Services/OrderService.php
@@ -4,6 +4,7 @@ namespace MollieShopware\Components\Services;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use MollieShopware\Components\Logger;
+use MollieShopware\Exceptions\OrderNotFoundException;
 use MollieShopware\Exceptions\TransactionNotFoundException;
 use MollieShopware\Models\Transaction;
 use Psr\Log\LoggerInterface;
@@ -36,7 +37,7 @@ class OrderService
      *
      * @param int $orderId
      *
-     * @return \Shopware\Models\Order\Order $order
+     * @return Order $order
      *
      * @throws \Exception
      */
@@ -47,10 +48,10 @@ class OrderService
         try {
             /** @var \Shopware\Models\Order\Repository $orderRepo */
             $orderRepo = $this->modelManager->getRepository(
-                \Shopware\Models\Order\Order::class
+                Order::class
             );
 
-            /** @var \Shopware\Models\Order\Order $order */
+            /** @var Order $order */
             $order = $orderRepo->find($orderId);
         } catch (\Exception $ex) {
 
@@ -128,9 +129,9 @@ class OrderService
     public function getShopwareOrderByNumber($orderNumber)
     {
         /** @var \Shopware\Models\Order\Repository $orderRepo */
-        $orderRepo = $this->modelManager->getRepository(\Shopware\Models\Order\Order::class);
+        $orderRepo = $this->modelManager->getRepository(Order::class);
 
-        /** @var \Shopware\Models\Order\Order $order */
+        /** @var Order $order */
         $order = $orderRepo->findOneBy([
             'number' => $orderNumber
         ]);
@@ -230,8 +231,8 @@ class OrderService
         $order = null;
         $items = [];
 
-        /** @var \Shopware\Models\Order\Order $order */
-        if ($orderId instanceof \Shopware\Models\Order\Order)
+        /** @var Order $order */
+        if ($orderId instanceof Order)
             $order = $orderId;
         else
             $order = $this->getOrderById($orderId);
@@ -318,15 +319,14 @@ class OrderService
         try {
             /** @var \Shopware\Models\Order\Repository $orderRepo */
             $orderRepo = $this->modelManager->getRepository(
-                \Shopware\Models\Order\Order::class
+                Order::class
             );
 
-            /** @var \Shopware\Models\Order\Order $order */
+            /** @var Order $order */
             $order = $orderRepo->findOneBy([
                 'temporaryId' => $sessionId
             ]);
-        }
-        catch (\Exception $ex) {
+        } catch (\Exception $ex) {
             $this->logger->error(
                 'Error when loading order by session ID: ' . $sessionId,
                 array(
@@ -337,4 +337,25 @@ class OrderService
 
         return $order;
     }
+
+    /**
+     * @param string $transactionId
+     * @return Order
+     * @throws OrderNotFoundException
+     */
+    public function getOrderByTransactionId(string $transactionId)
+    {
+        /** @var \Shopware\Models\Order\Repository $orderRepo */
+        $orderRepo = $this->modelManager->getRepository(Order::class);
+
+        /** @var Order $order */
+        $order = $orderRepo->findOneBy(['transactionId' => $transactionId]);
+
+        if (!$order instanceof Order) {
+            throw new OrderNotFoundException('Order for Transaction: ' . $transactionId . ' not found!');
+        }
+
+        return $order;
+    }
+
 }

--- a/Controllers/Frontend/Mollie.php
+++ b/Controllers/Frontend/Mollie.php
@@ -192,11 +192,11 @@ class Shopware_Controllers_Frontend_Mollie extends AbstractPaymentController
                 throw new Exception('Missing Transaction Number');
             }
 
-            $this->logger->debug('User returning from Mollie for Transaction ' . $transactionNumber);
+            $this->logger->debug('User is returning from Mollie for Transaction ' . $transactionNumber);
 
             $checkoutData = $this->checkoutReturn->finishTransaction($transactionNumber);
 
-            $this->logger->debug('Finished order for Transaction ' . $transactionNumber);
+            $this->logger->info('Finished checkout for Transaction ' . $transactionNumber);
 
 
             # prepare the view data (i dont know why)
@@ -490,7 +490,13 @@ class Shopware_Controllers_Frontend_Mollie extends AbstractPaymentController
             );
 
             $swOrderUpdater = new ShopwareOrderUpdater($this->config, $entityManager);
-            $swOrderBuilder = new ShopwareOrderBuilder($this, $this->logger);
+
+            $swOrderBuilder = new ShopwareOrderBuilder(
+                $this,
+                $orderService,
+                $this->logger
+            );
+
             $statusConverter = new MollieStatusConverter(
                 $paymentService,
                 new MollieRefundStatus()


### PR DESCRIPTION
if you configure to create shopware orders AFTER the payment, these orders will be created
when the user is being redirected back from Mollie to Shopware.

if the returnURL is called again after a while (manually....), or somehow multiple times due to a "back-forth" in the browser (weird behaviour when user click around randomly?!) during a real checkout....then the orders are created again.

the problem is a bug when using the Orders API...so the transaction ID "ord_xyz" is coming in, but the Shopware order will get the connected Transaction ID of the payment as transaction number which is, "tr_xyz".
So next time, when "ord_xyz" comes in, it cannot find an order because it would be "tr_xyz"...and then creates it again.

This also happens when another transaction number is used....so like the passthru-paypal RefNr. or a BankTransfer number.

What I did?!
I've removed the "updating to the correct transaction number" for the Shopware order, and ensured that it will be already created with the correct number.
So the detection of the "real number to use" has been moved up in the process....that solves everything.

Then i've just added a nice warning to see that it happened.

Also the basic concept is, that it should always work...nothing breaks on multiple times...only the createOrder is avoided.

