### PR TITLE
MOL-135: fix for payment-reference usage when order before payment

### DIFF
--- a/Facades/FinishCheckout/FinishCheckoutFacade.php
+++ b/Facades/FinishCheckout/FinishCheckoutFacade.php
@@ -174,7 +174,6 @@ class FinishCheckoutFacade
         # which is either tr_xxxx or ord_xxxx depending on the type
         # of payment and API we have used
         $transactionNumber = $transaction->getShopwareTransactionNumber();
-        $finalTransactionNumber = '';
 
         if ($transaction->isTypeOrder()) {
             $finalTransactionNumber = $this->swOrderUpdater->getFinalTransactionIdFromOrder($mollieOrder);
@@ -223,6 +222,14 @@ class FinishCheckoutFacade
         # make sure our transaction is correctly linked to the order
         $transaction->setOrderId($swOrder->getId());
         $this->repoTransactions->save($transaction);
+
+
+        # if we have created our order before the payment
+        # then we have to update the transaction ID here so that
+        # it will be our final transaction number
+        if ($this->config->createOrderBeforePayment()) {
+            $this->swOrderUpdater->updateTransactionId($swOrder, $finalTransactionNumber);
+        }
 
 
         # now we need to update the transaction identifier in the Shopware order.

--- a/Facades/FinishCheckout/Services/ShopwareOrderUpdater.php
+++ b/Facades/FinishCheckout/Services/ShopwareOrderUpdater.php
@@ -73,6 +73,22 @@ class ShopwareOrderUpdater
     }
 
     /**
+     * Updates the transaction ID of the provided Shopware order.
+     *
+     * @param Order $order
+     * @param $transactionId
+     * @throws \Doctrine\ORM\ORMException
+     * @throws \Doctrine\ORM\OptimisticLockException
+     */
+    public function updateTransactionId(Order $order, $transactionId)
+    {
+        $order->setTransactionId($transactionId);
+
+        $this->entityManger->persist($order);
+        $this->entityManger->flush($order);
+    }
+
+    /**
      * @param Order $swOrder
      * @param \Mollie\Api\Resources\Order $mollieOrder
      * @param Transaction $transaction


### PR DESCRIPTION
the new payment transaction usage wasnt applied on existing orders when these
are created before the payment

in that case we need the update again