### PR TITLE
MOL-148: Improve Payment Method Imports

### DIFF
--- a/Command/PaymentImportCommand.php
+++ b/Command/PaymentImportCommand.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace MollieShopware\Command;
+
+use MollieShopware\Components\Services\PaymentMethodService;
+use Psr\Log\LoggerInterface;
+use Shopware\Commands\ShopwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+
+class PaymentImportCommand extends ShopwareCommand
+{
+
+    /**
+     * @var PaymentMethodService
+     */
+    private $paymentMethodService;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+
+    /**
+     * @param PaymentMethodService $paymentMethodService
+     * @param LoggerInterface $logger
+     */
+    public function __construct(PaymentMethodService $paymentMethodService, LoggerInterface $logger)
+    {
+        $this->paymentMethodService = $paymentMethodService;
+        $this->logger = $logger;
+
+        parent::__construct();
+    }
+
+    /**
+     *
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('mollie:payments:import')
+            ->setDescription('Imports and updates all Mollie payment methods');
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int|void|null
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+        $io->title('MOLLIE Payment Methods Import');
+
+        try {
+
+            $this->logger->info('Starting payment methods import on CLI');
+
+            $importCount = $this->paymentMethodService->installPaymentMethods();
+
+            $this->logger->info($importCount . ' Payment Methods have been successfully imported on CLI');
+
+            $io->success($importCount . ' Payment Methods have been updated successfully!');
+
+        } catch (\Throwable $e) {
+
+            $this->logger->error(
+                'Error when importing payment methods on CLI',
+                array(
+                    'error' => $e->getMessage(),
+                )
+            );
+
+            $io->error($e->getMessage());
+        }
+    }
+
+}

--- a/Components/ApplePayDirect/Services/ApplePayPaymentMethod.php
+++ b/Components/ApplePayDirect/Services/ApplePayPaymentMethod.php
@@ -31,12 +31,7 @@ class ApplePayPaymentMethod
      */
     public function getPaymentMethod()
     {
-        $applePayDirect = $this->paymentMethodService->getPaymentMethod(
-            [
-                'name' => ShopwarePaymentMethod::APPLEPAYDIRECT,
-                'active' => true,
-            ]
-        );
+        $applePayDirect = $this->paymentMethodService->getActiveApplePayDirectMethod();
 
         if ($applePayDirect instanceof Payment) {
             return $applePayDirect;

--- a/Components/Installer/PaymentMethods/IconHtmlBuilder.php
+++ b/Components/Installer/PaymentMethods/IconHtmlBuilder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace MollieShopware\Components\Installer\PaymentMethods;
+
+use Mollie\Api\Resources\Method;
+
+class IconHtmlBuilder
+{
+
+    /**
+     * @param Method $method
+     * @return string
+     */
+    public function getIconHTML(Method $method)
+    {
+        return '<img src="' . $method->image->size1x . '" alt="' . $method->description . '" class="mollie-payment-icon" />';
+    }
+
+}

--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -49,6 +49,12 @@
             <argument type="service" id="mollie_shopware.components.logger"/>
         </service>
 
+        <service id="mollie_shopware.command.payment_import_command" class="MollieShopware\Command\PaymentImportCommand">
+            <tag name="console.command"/>
+            <argument type="service" id="mollie_shopware.payment_method_service"/>
+            <argument type="service" id="mollie_shopware.components.logger"/>
+        </service>
+
         <service id="mollie_shopware.payment_service" class="MollieShopware\Components\Services\PaymentService">
             <argument type="service" id="mollie_shopware.api_factory"/>
             <argument type="service" id="mollie_shopware.config"/>
@@ -56,13 +62,13 @@
             <argument>%shopware.custom%</argument>
         </service>
 
-        <service id="mollie_shopware.payment_method_service"
-                 class="MollieShopware\Components\Services\PaymentMethodService">
+        <service id="mollie_shopware.payment_method_service" class="MollieShopware\Components\Services\PaymentMethodService">
             <argument type="service" id="models"/>
             <argument type="service" id="mollie_shopware.api"/>
             <argument type="service" id="shopware.plugin_payment_installer"/>
             <argument type="service" id="template"/>
             <argument type="service" id="mollie_shopware.components.logger"/>
+            <argument>%mollie_shopware.plugin_name%</argument>
         </service>
 
         <service id="mollie_shopware.order_service" class="MollieShopware\Components\Services\OrderService">

--- a/Resources/views/frontend/plugins/payment/methods/main.tpl
+++ b/Resources/views/frontend/plugins/payment/methods/main.tpl
@@ -1,1 +1,0 @@
-<img src="{$method->image->size1x}" alt="{$method->description}" class="mollie-payment-icon" />


### PR DESCRIPTION
payment methods can now be imported with button since a while
unfortunately the deactivated payment methods got activated again

so i've refactored the full payment method installer.
it will checkf if methods are new, or just need to be updated, or even removed

it will also make sure that all things that can be changed by the merchant will not be overwritten again on an import (such as the active field)

i did also add better logs, and a CLI command that i used for development purpose, makes sense i think...