### PR TITLE
MOL-148: Payment installation after uninstalling plugin

### DIFF
--- a/Command/PaymentImportCommand.php
+++ b/Command/PaymentImportCommand.php
@@ -60,7 +60,7 @@ class PaymentImportCommand extends ShopwareCommand
 
             $this->logger->info('Starting payment methods import on CLI');
 
-            $importCount = $this->paymentMethodService->installPaymentMethods();
+            $importCount = $this->paymentMethodService->installPaymentMethods(false);
 
             $this->logger->info($importCount . ' Payment Methods have been successfully imported on CLI');
 

--- a/Controllers/Backend/MolliePayments.php
+++ b/Controllers/Backend/MolliePayments.php
@@ -26,7 +26,7 @@ class Shopware_Controllers_Backend_MolliePayments extends Shopware_Controllers_B
             /** @var PaymentMethodService $paymentMethodService */
             $paymentMethodService = $this->container->get('mollie_shopware.payment_method_service');
 
-            $importCount = $paymentMethodService->installPaymentMethods();
+            $importCount = $paymentMethodService->installPaymentMethods(false);
 
             $this->logger->info($importCount . ' Payment Methods have been successfully imported in Backend');
 

--- a/MollieShopware.php
+++ b/MollieShopware.php
@@ -230,8 +230,12 @@ class MollieShopware extends Plugin
 
         /** @var PaymentMethodService $paymentMethodService */
         $paymentMethodService = $this->getPaymentMethodService($context);
-        $paymentMethodService->installPaymentMethods();
 
+        # if we install the plugin from scratch, then we
+        # want to activate all payment methods
+        $paymentMethodService->installPaymentMethods(true);
+
+        
         // download apple pay merchant domain verification file of mollie
         $downloader = new ApplePayDomainFileDownloader();
         $downloader->downloadDomainAssociationFile(Shopware()->DocPath());


### PR DESCRIPTION
found a new case
when uninstalling the plugin, payments are disabled
but when being installed again, they should be activated again, 
except the deprecated ones that might not exist anymore ;)