### PR TITLE
MOL-158: Test if getInvoiceShippingTaxRate Method exists

### DIFF
--- a/Components/Shipping/Providers/CartShippingCostsProvider.php
+++ b/Components/Shipping/Providers/CartShippingCostsProvider.php
@@ -86,7 +86,13 @@ class CartShippingCostsProvider implements ShippingCostsProviderInterface
      */
     private function getTaxRate(Order $order)
     {
-        $taxRate = $order->getInvoiceShippingTaxRate();
+        $taxRate = null;
+
+        // This Method doesn't exists in early Shopware 5 Versions (<= 5.4)
+        // if the Method exists use it, if not calculate the TaxRate as fallback
+        if (method_exists($order, 'getInvoiceShippingTaxRate')) {
+            $taxRate = $order->getInvoiceShippingTaxRate();
+        }
 
         if ($taxRate !== null) {
             return $taxRate;


### PR DESCRIPTION
In earlier versions of Shopware the getInvoiceShippingTaxRate Method as well as the invoice_shipping_tax_rate column in the order table don't exist. So check if the method exists, otherwise calculate the tax rate by invoice shipping and invoice shipping net.