### PR TITLE
MOL-240: PHP 5.6 Compatiblity Fixes

### DIFF
--- a/Command/OrdersRefundCommand.php
+++ b/Command/OrdersRefundCommand.php
@@ -95,7 +95,7 @@ class OrdersRefundCommand extends ShopwareCommand
 
             $io->success('Order ' . $orderNumber . ' was successfully refunded.');
 
-        } catch (\Throwable $e) {
+        } catch (\Exception $e) {
 
             $this->logger->error(
                 'Error when processing Refund for Order ' . $orderNumber . ' on CLI',

--- a/Command/PaymentImportCommand.php
+++ b/Command/PaymentImportCommand.php
@@ -66,7 +66,7 @@ class PaymentImportCommand extends ShopwareCommand
 
             $io->success($importCount . ' Payment Methods have been updated successfully!');
 
-        } catch (\Throwable $e) {
+        } catch (\Exception $e) {
 
             $this->logger->error(
                 'Error when importing payment methods on CLI',

--- a/Components/MollieApiFactory.php
+++ b/Components/MollieApiFactory.php
@@ -122,7 +122,7 @@ class MollieApiFactory
             // set the api key based on the configuration
             $client->setApiKey($apiKey);
 
-        } catch (\Throwable $ex) {
+        } catch (\Exception $ex) {
             $this->logger->error(
                 'Fatal error with Mollie API Key. Invalid Key: ' . $apiKey,
                 array(

--- a/Components/Order/OrderCancellation.php
+++ b/Components/Order/OrderCancellation.php
@@ -149,7 +149,7 @@ class OrderCancellation
         /** @var CurrentCustomer $currentCustomer */
         $currentCustomer = new CurrentCustomer(Shopware()->Session(), Shopware()->Models());
 
-        if ($currentCustomer->getCurrentId() === $order->getCustomer()->getId()) {
+        if ((int)$currentCustomer->getCurrentId() === (int)$order->getCustomer()->getId()) {
             $this->basketService->restoreBasket($order);
         }
     }

--- a/Controllers/Backend/MollieOrders.php
+++ b/Controllers/Backend/MollieOrders.php
@@ -179,7 +179,7 @@ class Shopware_Controllers_Backend_MollieOrders extends Shopware_Controllers_Bac
 
             $this->returnSuccess('Order successfully refunded', $refund);
 
-        } catch (Throwable $ex) {
+        } catch (\Exception $ex) {
 
             $logger->error(
                 'Error when executing a full refund order in Shopware Backend',
@@ -254,7 +254,7 @@ class Shopware_Controllers_Backend_MollieOrders extends Shopware_Controllers_Bac
 
             $this->returnSuccess('Order line successfully refunded', $refund);
 
-        } catch (Throwable $ex) {
+        } catch (\Exception $ex) {
 
             $logger->error(
                 'Error when executing a partial refund order in Shopware Backend',

--- a/Controllers/Backend/MolliePayments.php
+++ b/Controllers/Backend/MolliePayments.php
@@ -34,7 +34,7 @@ class Shopware_Controllers_Backend_MolliePayments extends Shopware_Controllers_B
 
             die($message);
 
-        } catch (\Throwable $e) {
+        } catch (\Exception $e) {
 
             $this->logger->error(
                 'Error when importing payment methods in Backend',

--- a/Controllers/Frontend/Mollie.php
+++ b/Controllers/Frontend/Mollie.php
@@ -107,7 +107,7 @@ class Shopware_Controllers_Frontend_Mollie extends AbstractPaymentController
     }
 
     /**
-     * @throws ApiException
+     * @throws Exception
      */
     public function directAction()
     {
@@ -146,7 +146,7 @@ class Shopware_Controllers_Frontend_Mollie extends AbstractPaymentController
 
             $this->redirect($session->getCheckoutUrl());
 
-        } catch (Throwable $ex) {
+        } catch (\Exception $ex) {
 
             $this->logger->error(
                 'Error when starting Mollie checkout',
@@ -204,7 +204,8 @@ class Shopware_Controllers_Frontend_Mollie extends AbstractPaymentController
             # the original shopware way
             $this->redirectToFinish($checkoutData->getTemporaryId());
 
-        } catch (Throwable $ex) {
+        }
+        catch (\Exception $ex) {
 
             $this->logger->error(
                 'Checkout failed when returning to shop!',
@@ -221,7 +222,8 @@ class Shopware_Controllers_Frontend_Mollie extends AbstractPaymentController
 
             $this->redirectBack(self::ERROR_PAYMENT_FAILED);
 
-        } finally {
+        }
+        finally {
             if (!empty($transactionNumber)) {
                 $this->checkoutReturn->cleanupTransaction($transactionNumber);
             }
@@ -259,7 +261,7 @@ class Shopware_Controllers_Frontend_Mollie extends AbstractPaymentController
 
             echo json_encode($data, JSON_PRETTY_PRINT);
 
-        } catch (\Throwable $e) {
+        } catch (\Exception $e) {
 
             $this->logger->error(
                 'Error in Mollie Notification',
@@ -337,7 +339,7 @@ class Shopware_Controllers_Frontend_Mollie extends AbstractPaymentController
                 'success' => true,
             ]);
 
-        } catch (Throwable $ex) {
+        } catch (\Exception $ex) {
 
             $this->sendResponse([
                 'message' => $ex->getMessage(),
@@ -382,7 +384,7 @@ class Shopware_Controllers_Frontend_Mollie extends AbstractPaymentController
 
             die();
 
-        } catch (Throwable $ex) {
+        } catch (\Exception $ex) {
 
             $this->logger->error('Error when showing Credit Card Components: ' . $ex->getMessage());
 
@@ -554,7 +556,7 @@ class Shopware_Controllers_Frontend_Mollie extends AbstractPaymentController
                 $this->orderCancellation
             );
 
-        } catch (Throwable $ex) {
+        } catch (\Exception $ex) {
 
             $this->logger->emergency('Fatal Problem when preparing services! ' . $ex->getMessage());
 

--- a/Controllers/Frontend/MollieApplePayDirect.php
+++ b/Controllers/Frontend/MollieApplePayDirect.php
@@ -154,7 +154,7 @@ class Shopware_Controllers_Frontend_MollieApplePayDirect extends Shopware_Contro
             echo "";
             die();
 
-        } catch (Throwable $ex) {
+        } catch (\Exception $ex) {
 
             $this->logger->error(
                 'Error when adding product to apple pay cart',
@@ -239,7 +239,7 @@ class Shopware_Controllers_Frontend_MollieApplePayDirect extends Shopware_Contro
             echo json_encode($data);
             die();
 
-        } catch (Throwable $ex) {
+        } catch (\Exception $ex) {
 
             $this->logger->error(
                 'Error loading shippings for Mollie Apple Pay Direct',
@@ -302,7 +302,7 @@ class Shopware_Controllers_Frontend_MollieApplePayDirect extends Shopware_Contro
             echo json_encode($data);
             die();
 
-        } catch (Throwable $ex) {
+        } catch (\Exception $ex) {
 
             $this->logger->error(
                 'Error setting shipping for Mollie Apple Pay Direct',
@@ -344,7 +344,7 @@ class Shopware_Controllers_Frontend_MollieApplePayDirect extends Shopware_Contro
             echo "";
             die();
 
-        } catch (Throwable $ex) {
+        } catch (\Exception $ex) {
 
             $this->logger->error(
                 'Error restoring cart after Mollie Apple Pay Direct',
@@ -384,7 +384,7 @@ class Shopware_Controllers_Frontend_MollieApplePayDirect extends Shopware_Contro
 
             echo $response;
 
-        } catch (Exception $ex) {
+        } catch (\Exception $ex) {
 
             $this->logger->error(
                 'Error starting Mollie Apple Pay Direct session',
@@ -480,7 +480,7 @@ class Shopware_Controllers_Frontend_MollieApplePayDirect extends Shopware_Contro
                 ]
             );
 
-        } catch (Throwable $ex) {
+        } catch (\Exception $ex) {
 
             $this->logger->error(
                 'Error starting Mollie Apple Pay Direct payment',
@@ -561,7 +561,7 @@ class Shopware_Controllers_Frontend_MollieApplePayDirect extends Shopware_Contro
                 ]
             );
 
-        } catch (Throwable $ex) {
+        } catch (\Exception $ex) {
 
             $this->logger->error(
                 'Error finishing Mollie Apple Pay Direct payment',


### PR DESCRIPTION
had to revert to exception instead of throwable...php 5.6 compatibility :) 


also found an issue where php 5.6 cart restoring istn working due to int/string comparison