### PR TITLE
MOL-247: Ensure Payment is set in Session

### DIFF
--- a/Exceptions/PaymentMeanNotFoundException.php
+++ b/Exceptions/PaymentMeanNotFoundException.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace MollieShopware\Exceptions;
+
+
+use Exception;
+
+/**
+ * @copyright 2021 dasistweb GmbH (https://www.dasistweb.de)
+ */
+class PaymentMeanNotFoundException extends Exception
+{
+
+    /**
+     * @param $paymentMethod
+     */
+    public function __construct($paymentMethod)
+    {
+        parent::__construct('PaymentMean for ' . $paymentMethod . ' not found!');
+    }
+
+}


### PR DESCRIPTION
When the payment isn't set in session restore it from transaction before creating order.