### PR TITLE
Fix Missing Expired Mapping in Order API notifications

### DIFF
--- a/Components/Helpers/MollieStatusConverter.php
+++ b/Components/Helpers/MollieStatusConverter.php
@@ -70,6 +70,10 @@ class MollieStatusConverter
                 $targetStatus = PaymentStatus::MOLLIE_PAYMENT_FAILED;
             }
 
+            if ($paymentsResult[PaymentStatus::MOLLIE_PAYMENT_EXPIRED] == $paymentsResult['total']) {
+                $targetStatus = PaymentStatus::MOLLIE_PAYMENT_EXPIRED;
+            }
+
         } else {
 
             if ($order->isPaid()) {
@@ -80,6 +84,8 @@ class MollieStatusConverter
                 $targetStatus = PaymentStatus::MOLLIE_PAYMENT_CANCELED;
             } else if ($order->isCompleted()) {
                 $targetStatus = PaymentStatus::MOLLIE_PAYMENT_COMPLETED;
+            } else if ($order->isExpired()) {
+                $targetStatus = PaymentStatus::MOLLIE_PAYMENT_EXPIRED;
             }
 
         }
@@ -94,7 +100,6 @@ class MollieStatusConverter
         if ($this->refundStatus->isOrderPartiallyRefunded($order)) {
             $targetStatus = PaymentStatus::MOLLIE_PAYMENT_REFUNDED;
         }
-
 
         return $targetStatus;
     }

--- a/Components/Order/OrderUpdater.php
+++ b/Components/Order/OrderUpdater.php
@@ -114,6 +114,7 @@ class OrderUpdater
      * @param $status
      * @param $sendMail
      * @throws PaymentStatusNotFoundException
+     * @throws \Enlight_Event_Exception
      */
     private function updatePaymentStatus(Order $order, $status, $sendMail)
     {
@@ -191,7 +192,7 @@ class OrderUpdater
         }
 
         if ($shopwareStatus === null) {
-            throw new PaymentStatusNotFoundException($status);
+            throw new PaymentStatusNotFoundException('Unable to get Shopware Payment Status from Mollie Payment Status: ' . $status);
         }
 
         $this->sOrder->setPaymentStatus(

--- a/Exceptions/PaymentStatusNotFoundException.php
+++ b/Exceptions/PaymentStatusNotFoundException.php
@@ -6,11 +6,12 @@ class PaymentStatusNotFoundException extends \Exception
 {
 
     /**
-     * @param $status
+     * PaymentStatusNotFoundException constructor.
+     * @param $errorMessage
      */
-    public function __construct($status)
+    public function __construct($errorMessage)
     {
-        parent::__construct('Payment Status: ' . $status . ' not found!');
+        parent::__construct($errorMessage);
     }
 
 }

--- a/Facades/Notifications/Notifications.php
+++ b/Facades/Notifications/Notifications.php
@@ -150,10 +150,9 @@ class Notifications
             $mollieStatus = $this->statusConverter->getMolliePaymentStatus($molliePayment);
         }
 
-        if ($mollieStatus === null) {
-            throw new PaymentStatusNotFoundException('Unable to get status from Mollie for this transaction or order!');
+        if (empty($mollieStatus)) {
+            throw new PaymentStatusNotFoundException('Unable to get status from Mollie for transaction ' . $transactionID . '!');
         }
-
 
         # -----------------------------------------------------------------------------------------------------
         # UPDATE PAYMENT STATUS + ORDER STATUS


### PR DESCRIPTION
expired status mapping was just missing for the orders api
that means there was an error in the notification when expired has been received

i did also improve the logs a bit