### PR TITLE
MOL-197: Improved getting Mollie Orders and Payments

### DIFF
--- a/Exceptions/MolliePaymentNotFound.php
+++ b/Exceptions/MolliePaymentNotFound.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace MollieShopware\Exceptions;
+
+
+/**
+ * @copyright 2021 dasistweb GmbH (https://www.dasistweb.de)
+ */
+class MolliePaymentNotFound extends \Exception
+{
+
+    /**
+     * @param $orderId
+     */
+    public function __construct($orderId)
+    {
+        parent::__construct('Mollie payment for order : ' . $orderId . ' not found!');
+    }
+
+}

--- a/Facades/FinishCheckout/FinishCheckoutFacade.php
+++ b/Facades/FinishCheckout/FinishCheckoutFacade.php
@@ -250,10 +250,10 @@ class FinishCheckoutFacade
         # please note, the payment/order is loaded again from Mollie! we would actually have it
         # but I'm not quite sure if its better to reload it again from the server due to some changes above.
         if ($transaction->isTypeOrder()) {
-            $mollieOrder = $this->paymentService->getMollieOrder($swOrder);
+            $mollieOrder = $this->paymentService->getMollieOrder($swOrder, $transaction);
             $mollieStatus = $this->statusConverter->getMollieOrderStatus($mollieOrder);
         } else {
-            $molliePayment = $this->paymentService->getMolliePayment($swOrder);
+            $molliePayment = $this->paymentService->getMolliePayment($swOrder, $transaction);
             $mollieStatus = $this->statusConverter->getMolliePaymentStatus($molliePayment);
         }
 

--- a/Facades/Notifications/Notifications.php
+++ b/Facades/Notifications/Notifications.php
@@ -131,7 +131,7 @@ class Notifications
 
             # get the order from the mollie api
             # and extract the status from its data
-            $mollieOrder = $this->paymentService->getMollieOrder($order);
+            $mollieOrder = $this->paymentService->getMollieOrder($order, $transaction);
             $mollieStatus = $this->statusConverter->getMollieOrderStatus($mollieOrder);
 
         } else {
@@ -146,7 +146,7 @@ class Notifications
 
             # get the payment from our molli api
             # and extract its status 
-            $molliePayment = $this->paymentService->getMolliePayment($order, $transaction->getMolliePaymentId());
+            $molliePayment = $this->paymentService->getMolliePayment($order, $transaction);
             $mollieStatus = $this->statusConverter->getMolliePaymentStatus($molliePayment);
         }
 

--- a/Models/TransactionRepository.php
+++ b/Models/TransactionRepository.php
@@ -65,7 +65,7 @@ class TransactionRepository extends ModelRepository
      * Get the most recent transaction for an order
      *
      * @param Order $order
-     * @return Transaction
+     * @return Transaction|null
      */
     public function getMostRecentTransactionForOrder(Order $order)
     {


### PR DESCRIPTION
In the Logs of MOL-197 can be found the following Error: "error":"Call to a member function getMollieOrderId() on null"
This can only happen in PaymentService, as at all other places where this method is called it's checked before the method call if the object is of the right type.
In PaymentService I found unnecessary loading of the transaction to get the orderId (which caused the error when the loading returned null) although the transaction is already present and checked in all places where this method of the PaymentService is used, so I added the orderId as parameter for the method and don't try to load the transaction. 
The exactly same happend in the method to load the Mollie Payment.