### PR TITLE
MOL-352: Basket Restore for SWAG Custom Products Plugin

### DIFF
--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -85,6 +85,7 @@
         <service id="mollie_shopware.basket_service" class="MollieShopware\Components\Services\BasketService">
             <argument type="service" id="models"/>
             <argument type="service" id="mollie_shopware.components.logger"/>
+            <argument type="service" id="service_container"/>
         </service>
 
         <service id="mollie_shopware.ideal_service" class="MollieShopware\Components\Services\IdealService">


### PR DESCRIPTION
Added Compatibility for Restore Basket (create order before Payment) for SWAG Custom Products Plugin

The SWAG Custom Products Plugin generates Hashes for the possible Configurations. These are stored in the OrderItem and read from the Request when the Item is added to the Basket. Depending on the Hash and the Configuration for the Hash it adds the configuration Items (Mode 4, Surcharge/Discount Mode) and the normal Execution of the sAddArticle Method from sBasket is stopped afterwards.

So for adding Compatibility for this Plugin check if the Hash exists in the orderDetails Object Attributes and if yes store it in the Request.