### PR TITLE
NTR: Shopware as Dev Dependency

### DIFF
--- a/Models/TransactionRepository.php
+++ b/Models/TransactionRepository.php
@@ -22,11 +22,7 @@ class TransactionRepository extends ModelRepository
      * @throws \Exception
      *
      */
-    public function create(
-        Order $order = null,
-        \Mollie\Api\Resources\Order $mollieOrder = null,
-        \Mollie\Api\Resources\Payment $molliePayment = null
-    )
+    public function create(Order $order = null, $mollieOrder = null, $molliePayment = null)
     {
         $transaction = new Transaction();
         $transactionId = $this->getLastId() + 1;

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,13 @@
 {
   "name": "mollie/shopware",
   "require": {
-    "php": ">=5.6"
   },
   "require-dev": {
     "phpunit/phpunit": "*",
     "phpstan/phpstan": "^0.12",
     "doctrine/collections": "1.6.4",
-    "monolog/monolog": "1.25.3"
+    "monolog/monolog": "1.25.3",
+    "shopware/shopware": "~5.6.9"
   },
   "autoload-dev": {
     "psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,9 +11,10 @@ parameters:
         - Controllers/*
         - Facades/*
         - Gateways/*
-        - Models/*
         - Resources/*
         - Services/*
         - Subscriber/*
         - vendor/*
         - MollieShopware.php
+
+        


### PR DESCRIPTION
wanted to improve phpstan and found a new repo that requires shopware as dev dependency

so i've added shopware as require-dev and PHPStan now sees the models folders as OK :)

...also had to remove the argument types in the constructor...but now it works for stan