### PR TITLE
MOL-351: Klarna CLI mark invalid orders as processed

### DIFF
--- a/Command/KlarnaShippingCommand.php
+++ b/Command/KlarnaShippingCommand.php
@@ -2,11 +2,12 @@
 
 namespace MollieShopware\Command;
 
-use Mollie\Api\MollieApiClient;
+use Doctrine\ORM\EntityNotFoundException;
 use MollieShopware\Components\Config;
 use MollieShopware\Components\Constants\PaymentMethod;
 use MollieShopware\Components\Helpers\MollieShopSwitcher;
-use MollieShopware\Components\Logger;
+use MollieShopware\Facades\FinishCheckout\Services\MollieStatusValidator;
+use MollieShopware\Gateways\MollieGatewayInterface;
 use MollieShopware\Models\Transaction;
 use MollieShopware\Models\TransactionRepository;
 use Psr\Log\LoggerInterface;
@@ -15,6 +16,7 @@ use Shopware\Components\Model\ModelManager;
 use Shopware\Models\Order\Order;
 use Shopware\Models\Order\Repository;
 use Shopware\Models\Order\Status;
+use Shopware\Models\Shop\Shop;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -22,43 +24,77 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class KlarnaShippingCommand extends ShopwareCommand
 {
+
+
+    const LOG_PREFIX = 'CLI Klarna: ';
+
     /**
      * @var Config
      */
     private $config;
 
     /**
-     * @var ModelManager
+     * @var MollieGatewayInterface
      */
-    private $modelManager;
+    private $gwMollie;
 
     /**
-     * @var MollieApiClient
+     * @var MollieStatusValidator
      */
-    private $apiClient;
+    private $statusValidator;
 
     /**
      * @var LoggerInterface
      */
     private $logger;
 
+    /**
+     * @var \Shopware\Models\Shop\Repository
+     */
+    private $repoShops;
 
-    public function __construct(
-        Config $config,
-        ModelManager $modelManager,
-        MollieApiClient $apiClient,
-        LoggerInterface $logger,
-        $name = null
-    )
+    /**
+     * @var Repository
+     */
+    private $repoOrders;
+
+    /**
+     * @var TransactionRepository
+     */
+    private $repoTransactions;
+
+
+    private $countSuccess;
+    private $countFailed;
+    private $countSkipped;
+    private $countRepaired;
+
+
+    /**
+     * @param Config $config
+     * @param ModelManager $modelManager
+     * @param MollieGatewayInterface $gwMollie
+     * @param LoggerInterface $logger
+     * @param null $name
+     */
+    public function __construct(Config $config, ModelManager $modelManager, MollieGatewayInterface $gwMollie, LoggerInterface $logger, $name = null)
     {
         parent::__construct($name);
 
         $this->config = $config;
-        $this->modelManager = $modelManager;
-        $this->apiClient = $apiClient;
+        $this->gwMollie = $gwMollie;
         $this->logger = $logger;
+
+        $this->statusValidator = new MollieStatusValidator();
+
+        $this->repoShops = $modelManager->getRepository(Shop::class);
+        $this->repoOrders = $modelManager->getRepository(Order::class);
+        $this->repoTransactions = $modelManager->getRepository(Transaction::class);
     }
 
+    /**
+     *
+     */
     public function configure()
     {
         $this
@@ -79,173 +115,217 @@ class KlarnaShippingCommand extends ShopwareCommand
         $io->text('Searching for all non-shipped Klarna orders and mark them as shipped if the status is correct...');
 
 
-        $notShippableStates = array(
-            Status::PAYMENT_STATE_OPEN,
-            Status::PAYMENT_STATE_THE_PROCESS_HAS_BEEN_CANCELLED
+        /** @var Transaction[] $transactions */
+        $transactions = $this->repoTransactions->findBy(
+            [
+                'isShipped' => false,
+                'paymentMethod' => 'mollie_' . PaymentMethod::KLARNA_PAY_LATER
+            ]
         );
 
 
-        /** @var Transaction[] $transactions */
-        $transactions = null;
-
-        /** @var TransactionRepository $transactionRepository */
-        $transactionRepository = $this->modelManager->getRepository(Transaction::class);
-
-        if ($transactionRepository !== null) {
-            $transactions = $transactionRepository->findBy([
-                'isShipped' => false,
-                'paymentMethod' => 'mollie_' . PaymentMethod::KLARNA_PAY_LATER
-            ]);
-        }
-
         if ($transactions === null || !is_array($transactions)) {
             $io->success("No Mollie Transactions found!");
+            return;
         }
 
 
-        $countSuccess = 0;
-        $countFailed = 0;
-        $countSkipped = 0;
-        $countRepaired = 0;
-
-        if ($transactions !== null && is_array($transactions)) {
-
-            $io->text('Found ' . count($transactions) . ' orders that should be processed.');
-
-            $switcher = new MollieShopSwitcher($this->container);
-
-            $tableView = new Table($output);
-            $tableView->setHeaders(['order number', 'shipping status', 'error message', 'shop name']);
-
-            /** @var Repository $orderRepository */
-            $orderRepository = $this->modelManager->getRepository(Order::class);
+        $this->countSuccess = 0;
+        $this->countFailed = 0;
+        $this->countSkipped = 0;
+        $this->countRepaired = 0;
 
 
-            /** @var Transaction $transaction */
-            foreach ($transactions as $transaction) {
+        $io->text('Found ' . count($transactions) . ' orders that should be processed.');
+
+        $tableView = new Table($output);
+        $tableView->setHeaders($this->buildHeadline());
+
+
+        /** @var Transaction $transaction */
+        foreach ($transactions as $transaction) {
+
+            try {
+
+                /** @var Order|null $swOrder */
+                $swOrder = null;
+
+                $shopID = $transaction->getShopId();
+
+                if ($shopID <= 0) {
+
+                    # search for the shop ID in the connected
+                    # order of the transaction (if existing)
+                    $shopID = $this->getShopIdOfOrder($transaction);
+
+                    if ($shopID > 0) {
+                        # now repair the transaction
+                        $transaction->setShopId($shopID);
+                        $this->repoTransactions->save($transaction);
+                    }
+                }
+
+                # -------------------------------------------------------------------
+
+                if ($shopID <= 0) {
+
+                    $tableView->addRow(
+                        $this->buildRow(
+                            $transaction->getId(),
+                            '-',
+                            '-',
+                            '-',
+                            'No Order and thus no shop found for this transaction! Please verify this data entry!',
+                            '-'
+                        )
+                    );
+
+                    $this->logger->error(self::LOG_PREFIX . 'No Shop ID found for transaction: ' . $transaction->getId() . '!');
+
+                    $this->countFailed++;
+                    continue;
+                }
+
+
+                $shop = $this->repoShops->find($shopID);
+
+                $this->switchApiToShop($shopID);
+
+                $mollieOrderID = $transaction->getMollieOrderId();
+
+                /** @var \Mollie\Api\Resources\Order $mollieOrder */
+                $mollieOrder = null;
 
                 try {
-                    /** @var Order|null $order */
-                    $order = null;
 
-                    if ($transaction->getOrderId() === null) {
-                        $countFailed++;
+                    # now that we know in what shop it has been ordered (and thus, what API key we need),
+                    # we can try to fetch the order from the Mollie API
+                    $mollieOrder = $this->gwMollie->getOrder($mollieOrderID);
 
-                        $tableView->addRow([$transaction->getOrderNumber(), '', 'transaction does not have an order ID. Every Klarna order must have one.']);
+                } catch (\Exception $ex) {
+                    # "CLOSE" ORDERS THAT DO NOT EXIST IN MOLLIE ----------------------------------------------------------------
+                    # if mollie does not contain that order
+                    # make sure to show an error
+                    $tableView->addRow(
+                        $this->buildRow(
+                            $transaction->getId(),
+                            '-',
+                            '-',
+                            '-',
+                            'No Order found in Mollie for ID: ' . $mollieOrderID,
+                            $shop->getName()
+                        )
+                    );
 
-                        $this->logger->error('Klarna Ship Command: No order ID found for transaction: ' . $transaction->getId() . ' in Shopware. Please verify your data!');
+                    $this->logger->error(
+                        self::LOG_PREFIX . 'Order ' . $mollieOrderID . ' not found in Mollie',
+                        array(
+                            'data' => array(
+                                'shopId' => $shopID,
+                            ))
+                    );
 
-                        continue;
-                    }
-
-                    /** @var Order|null $order */
-                    $order = $orderRepository->find($transaction->getOrderId());
-
-                    if ($order === null) {
-                        $countFailed++;
-
-                        $tableView->addRow([$transaction->getOrderNumber(), '', 'transaction does not have an order in shopware']);
-
-                        $this->logger->error('Klarna Ship Command: No order found for transaction: ' . $transaction->getId() . ' in Shopware. Please verify your data!');
-
-                        continue;
-                    }
-
-                    # get the correct configuration
-                    # from the sub shop of the current order
-                    $this->config = $switcher->getConfig($order->getShop()->getId());
-                    $this->apiClient = $switcher->getMollieApi($order->getShop()->getId());
-
-
-                    # now request the order object from mollie
-                    # this is the current entity in their system
-                    $mollieOrder = $this->apiClient->orders->get($transaction->getMollieId());
-
-                    if ($mollieOrder === null) {
-                        $tableView->addRow([$transaction->getOrderNumber(), '', 'no order found in Mollie']);
-
-                        $countFailed++;
-                        continue;
-                    }
-
-                    # REPAIR ORDERS ALREADY SHIPPED ----------------------------------------------------------------
-                    if ($mollieOrder->shipments()->count() > 0) {
-                        $tableView->addRow([$transaction->getOrderNumber(), $order->getOrderStatus()->getName(), 'Already shipped. Repairing order, must not be shipped again', $order->getShop()->getName()]);
-
-                        $transaction->setIsShipped(true);
-                        $transactionRepository->save($transaction);
-
-                        $countRepaired++;
-                        continue;
-                    }
-
-                    # "CLOSE" FINALIZED ORDERS ----------------------------------------------------------------
-                    if ($mollieOrder->isCanceled() || $mollieOrder->isExpired()) {
-                        $tableView->addRow([$transaction->getOrderNumber(), $order->getOrderStatus()->getName(), 'order is cancelled or expired in Mollie. Mark it as "processed"']);
-
-                        $transaction->setIsShipped(true);
-                        $transactionRepository->save($transaction);
-
-                        $countRepaired++;
-                        continue;
-                    }
-
-
-                    # KEEP PENDING ORDERS "OPEN" ----------------------------------------------------------------
-                    if (in_array($order->getPaymentStatus()->getId(), $notShippableStates, true)) {
-                        $tableView->addRow([$transaction->getOrderNumber(), $order->getOrderStatus()->getName(), 'payment status is not allowed for shipping']);
-
-                        $countSkipped++;
-                        continue;
-                    }
-
-                    # KEEP ORDERS WITH OTHER STATUS "OPEN" ----------------------------------------------------------------
-                    # we wait until the klarna shipping status is reached
-                    if ($order->getOrderStatus()->getId() !== $this->config->getKlarnaShipOnStatus()) {
-                        $tableView->addRow(
-                            [
-                                $transaction->getOrderNumber(),
-                                $order->getOrderStatus()->getName(),
-                                'order status is not at the configured shippable value',
-                                $order->getShop()->getName()
-                            ]
-                        );
-
-                        $countSkipped++;
-                        continue;
-                    }
-
-
-                    $tableView->addRow([$transaction->getOrderNumber(), $order->getOrderStatus()->getName(), '', $order->getShop()->getName()]);
-                    # finally ship our order
-                    $mollieOrder->shipAll();
-
-                    # mark it as "shipped" so that it isn't
-                    # processed over and over again
-                    $transaction->setIsShipped(true);
-                    $transactionRepository->save($transaction);
-
-                    $countSuccess++;
-
-                } catch (\Exception $e) {
-                    $countFailed++;
-                    $io->error($e->getMessage());
-                    $this->logger->error('Klarna Ship Command: ' . $e->getMessage());
+                    $this->countFailed++;
+                    continue;
                 }
-            }
 
-            $tableView->render();
+                
+                # REPAIR ORDERS ALREADY SHIPPED ----------------------------------------------------------------
+                if ($this->isAlreadyShipped($transaction, $mollieOrder, $tableView, $shop)) {
+                    continue;
+                }
+
+                # "CLOSE" INVALID ORDERS ----------------------------------------------------------------
+                # now check if the order from mollie is actually valid
+                # if it was never authorized, paid or valid at all, then it was never completed
+                # and thus needs to be marked as "processed" to avoid that it gets used in here over and over again.
+                if (!$this->isOrderSuccessful($transaction, $mollieOrder, $tableView, $shop)) {
+                    continue;
+                }
+
+                # CHECK DATA INTEGRITY WITH ORDERS ----------------------------------------------------------------
+                # these are bad errors.
+                # it means that our mollie order is completely valid and paid, and also NOT yet shipped
+                # but somehow we do not have a linked or existing order in shopware!
+                if (!$this->hasTransactionOrderID($transaction, $mollieOrder, $tableView, $shop)) {
+                    continue;
+                }
+
+                if (!$this->hasTransactionOrder($transaction, $mollieOrder, $tableView, $shop)) {
+                    continue;
+                }
+
+
+                /** @var Order|null $order */
+                $swOrder = $this->repoOrders->find($transaction->getOrderId());
+
+                
+                # VERIFY PAYMENT STATUS ----------------------------------------------------------------
+                # now that we have our shopware order, make sure to keep it untouched
+                # if the payment status is in the list of our NOT_SHIPPABLE states.
+                if (!$this->isShippablePaymentStatus($transaction, $swOrder, $tableView, $shop)) {
+                    continue;
+                }
+
+                # VERIFY ORDER STATUS ----------------------------------------------------------------
+                # this checks our target order status from the plugin configuration
+                # if this is not the one where we trigger a shipping then just continue
+                if (!$this->isShippableOrderStatus($transaction, $swOrder, $tableView, $shop)) {
+                    continue;
+                }
+
+
+                try {
+
+                    $this->shipOrder(
+                        $transaction,
+                        $mollieOrder,
+                        $swOrder,
+                        $tableView,
+                        $shop
+                    );
+
+                } catch (\Exception $ex) {
+
+                    $tableView->addRow(
+                        $this->buildRow(
+                            $transaction->getId(),
+                            $transaction->getOrderNumber(),
+                            $swOrder->getOrderStatus()->getName(),
+                            $swOrder->getPaymentStatus()->getName(),
+                            'Failed: ' . $ex->getMessage(),
+                            $shop->getName()
+                        )
+                    );
+
+                    $this->logger->error(self::LOG_PREFIX . $ex->getMessage());
+
+                    $this->countFailed++;
+                    continue;
+                }
+
+            } catch (\Exception $e) {
+
+                $this->countFailed++;
+
+                $io->error($e->getMessage());
+
+                $this->logger->error(self::LOG_PREFIX . $e->getMessage());
+            }
         }
+
+        $tableView->render();
+
 
         $io->section('Klarna Shipping command executed...');
 
         $io->table(
             ['Status', 'Orders'],
             [
-                ['Successful Orders', $countSuccess],
-                ['Failed Orders', $countFailed,],
-                ['Skipped Orders', $countSkipped],
-                ['Repaired Orders', $countRepaired],
+                ['Successful Orders', $this->countSuccess],
+                ['Failed Orders', $this->countFailed,],
+                ['Skipped Orders', $this->countSkipped],
+                ['Repaired Orders', $this->countRepaired],
             ]
         );
 
@@ -253,11 +333,319 @@ class KlarnaShippingCommand extends ShopwareCommand
         $io->text('The repaired orders have been marked as shipped in Shopware because they are already shipped in Mollie.');
         $io->text("Thus, they won't be processed again the next time you run this command!");
 
-        if ($countFailed > 0) {
+        if ($this->countFailed > 0) {
             $io->error('Klarna Shipping failed');
         } else {
             $io->success('Klarna Shipping successful');
         }
 
     }
+
+    /**
+     * @param $shopId
+     * @throws \Mollie\Api\Exceptions\ApiException
+     * @throws \Mollie\Api\Exceptions\IncompatiblePlatform
+     */
+    private function switchApiToShop($shopId)
+    {
+        $switcher = new MollieShopSwitcher($this->container);
+
+        $this->config = $switcher->getConfig($shopId);
+
+        $clientForShop = $switcher->getMollieApi($shopId);
+
+        $this->gwMollie->switchClient($clientForShop);
+    }
+
+    /**
+     * @param Transaction $transaction
+     * @return int
+     */
+    private function getShopIdOfOrder(Transaction $transaction)
+    {
+        if ($transaction->getOrderId() === null) {
+            return 0;
+        }
+
+        try {
+
+            /** @var Order|null $order */
+            $order = $this->repoOrders->find($transaction->getOrderId());
+
+            return $order->getShop()->getId();
+
+        } catch (EntityNotFoundException $ex) {
+            return 0;
+        }
+    }
+
+
+    /**
+     * @param Transaction $transaction
+     * @param \Mollie\Api\Resources\Order $mollieOrder
+     * @param Table $table
+     * @param Shop $shop
+     * @return bool
+     * @throws \Doctrine\ORM\ORMException
+     * @throws \Doctrine\ORM\OptimisticLockException
+     */
+    private function isAlreadyShipped(Transaction $transaction, \Mollie\Api\Resources\Order $mollieOrder, Table $table, Shop $shop)
+    {
+        if ($mollieOrder->shipments()->count() <= 0) {
+            return false;
+        }
+
+        $table->addRow(
+            $this->buildRow(
+                $transaction->getId(),
+                '-',
+                '-',
+                '-',
+                'Transaction: ' . $mollieOrder->id . ' already shipped. Repair it and mark it as "processed".',
+                $shop->getName()
+            )
+        );
+
+        $transaction->setIsShipped(true);
+        $this->repoTransactions->save($transaction);
+
+        $this->countRepaired++;
+
+        return true;
+    }
+
+    /**
+     * @param Transaction $transaction
+     * @param \Mollie\Api\Resources\Order $mollieOrder
+     * @param Table $table
+     * @param Shop $shop
+     * @return bool
+     * @throws \Doctrine\ORM\ORMException
+     * @throws \Doctrine\ORM\OptimisticLockException
+     */
+    private function isOrderSuccessful(Transaction $transaction, \Mollie\Api\Resources\Order $mollieOrder, Table $table, Shop $shop)
+    {
+        $isOrderSuccessful = $this->statusValidator->didOrderCheckoutSucceed($mollieOrder);
+
+        if ($isOrderSuccessful) {
+            return true;
+        }
+
+        $table->addRow(
+            $this->buildRow(
+                $transaction->getId(),
+                '-',
+                '-',
+                '-',
+                'Order was never successful. Mark it as "processed".',
+                $shop->getName()
+            )
+        );
+
+        $transaction->setIsShipped(true);
+        $this->repoTransactions->save($transaction);
+
+        $this->countRepaired++;
+
+        return false;
+    }
+
+    /**
+     * @param Transaction $transaction
+     * @param \Mollie\Api\Resources\Order $mollieOrder
+     * @param Table $table
+     * @param Shop $shop
+     * @return bool
+     */
+    private function hasTransactionOrderID(Transaction $transaction, \Mollie\Api\Resources\Order $mollieOrder, Table $table, Shop $shop)
+    {
+        if ($transaction->getOrderId() !== null) {
+            return true;
+        }
+
+        $table->addRow(
+            $this->buildRow(
+                $transaction->getId(),
+                '-',
+                '-',
+                '-',
+                'Transaction has no OrderID in Shopware. Every Klarna order must have an order. Please verify this transaction in Shopware.',
+                $shop->getName()
+            )
+        );
+
+        $this->logger->error(self::LOG_PREFIX . 'No order ID found for transaction: ' . $transaction->getId() . ' in Shopware. Please verify your data!');
+
+        $this->countFailed++;
+
+        return false;
+    }
+
+    /**
+     * @param Transaction $transaction
+     * @param \Mollie\Api\Resources\Order $mollieOrder
+     * @param Table $table
+     * @param Shop $shop
+     * @return bool
+     */
+    private function hasTransactionOrder(Transaction $transaction, \Mollie\Api\Resources\Order $mollieOrder, Table $table, Shop $shop)
+    {
+        /** @var Order|null $order */
+        $swOrder = $this->repoOrders->find($transaction->getOrderId());
+
+        if ($swOrder !== null) {
+            return true;
+        }
+
+        $table->addRow(
+            $this->buildRow(
+                $transaction->getId(),
+                '-',
+                '-',
+                '-',
+                'Linked order with ID ' . $transaction->getOrderId() . ' does not exist in Shopware. Please verify this in Shopware.',
+                $shop->getName()
+            )
+        );
+
+        $this->logger->error(self::LOG_PREFIX . 'No order found for transaction: ' . $transaction->getId() . ' and orderID' . $transaction->getOrderId() . ' in Shopware. Please verify your data!');
+
+        $this->countFailed++;
+
+        return false;
+    }
+
+
+    /**
+     * @param Transaction $transaction
+     * @param Order $swOrder
+     * @param Table $table
+     * @param Shop $shop
+     * @return bool
+     */
+    private function isShippablePaymentStatus(Transaction $transaction, Order $swOrder, Table $table, Shop $shop)
+    {
+        $notShippableStates = array(
+            Status::PAYMENT_STATE_OPEN,
+            Status::PAYMENT_STATE_THE_PROCESS_HAS_BEEN_CANCELLED
+        );
+
+        if (!in_array($swOrder->getPaymentStatus()->getId(), $notShippableStates, true)) {
+            return true;
+        }
+
+        $table->addRow(
+            $this->buildRow(
+                $transaction->getId(),
+                $swOrder->getNumber(),
+                $swOrder->getOrderStatus()->getName(),
+                $swOrder->getPaymentStatus()->getName(),
+                'Payment Status is not allowed for shipping.',
+                $shop->getName()
+            )
+        );
+
+        $this->countSkipped++;
+
+        return false;
+    }
+
+    /**
+     * @param Transaction $transaction
+     * @param Order $swOrder
+     * @param Table $table
+     * @param Shop $shop
+     * @return bool
+     */
+    private function isShippableOrderStatus(Transaction $transaction, Order $swOrder, Table $table, Shop $shop)
+    {
+        if ($swOrder->getOrderStatus()->getId() === $this->config->getKlarnaShipOnStatus()) {
+            return true;
+        }
+
+        $table->addRow(
+            $this->buildRow(
+                $transaction->getId(),
+                $transaction->getOrderNumber(),
+                $swOrder->getOrderStatus()->getName(),
+                $swOrder->getPaymentStatus()->getName(),
+                'This order status is not configured to trigger a shipping.',
+                $shop->getName()
+            )
+        );
+
+        $this->countSkipped++;
+
+        return false;
+    }
+
+    /**
+     * @param Transaction $transaction
+     * @param \Mollie\Api\Resources\Order $mollieOrder
+     * @param Order $swOrder
+     * @param Table $table
+     * @param Shop $shop
+     * @throws \Doctrine\ORM\ORMException
+     * @throws \Doctrine\ORM\OptimisticLockException
+     */
+    private function shipOrder(Transaction $transaction, \Mollie\Api\Resources\Order $mollieOrder, Order $swOrder, Table $table, Shop $shop)
+    {
+        # finally ship our order
+        $mollieOrder->shipAll();
+
+        # mark it as "shipped" so that it isn't
+        # processed over and over again
+        $transaction->setIsShipped(true);
+        $this->repoTransactions->save($transaction);
+
+        $table->addRow(
+            $this->buildRow(
+                $transaction->getId(),
+                $transaction->getOrderNumber(),
+                $swOrder->getOrderStatus()->getName(),
+                $swOrder->getPaymentStatus()->getName(),
+                'Shipping instructions have been successfully sent to Mollie.',
+                $shop->getName()
+            )
+        );
+
+        $this->countSuccess++;
+    }
+
+    /**
+     * @return array
+     */
+    private function buildHeadline()
+    {
+        return [
+            'Transaction',
+            'Shop',
+            'Order',
+            'Order Status',
+            'Payment Status',
+            'Error',
+        ];
+    }
+
+    /**
+     * @param $transactionId
+     * @param $orderNumber
+     * @param $orderStatus
+     * @param $paymentStatus
+     * @param $message
+     * @param $shop
+     * @return array
+     */
+    private function buildRow($transactionId, $orderNumber, $orderStatus, $paymentStatus, $message, $shop)
+    {
+        return [
+            $transactionId,
+            $shop,
+            $orderNumber,
+            $orderStatus,
+            $paymentStatus,
+            $message,
+        ];
+    }
+
 }

--- a/Gateways/Mollie/MollieGateway.php
+++ b/Gateways/Mollie/MollieGateway.php
@@ -28,6 +28,15 @@ class MollieGateway implements MollieGatewayInterface
 
 
     /**
+     * @param MollieApiClient $client
+     * @return void
+     */
+    public function switchClient(MollieApiClient $client)
+    {
+        $this->apiClient = $client;
+    }
+
+    /**
      * @param $orderId
      * @return \Mollie\Api\Resources\Order
      * @throws \Mollie\Api\Exceptions\ApiException

--- a/Gateways/MollieGatewayInterface.php
+++ b/Gateways/MollieGatewayInterface.php
@@ -3,19 +3,26 @@
 namespace MollieShopware\Gateways;
 
 use Mollie\Api\MollieApiClient;
+use Mollie\Api\Resources\Order;
+use Mollie\Api\Resources\Payment;
 
 interface MollieGatewayInterface
 {
 
     /**
+     * @param MollieApiClient $client
+     */
+    public function switchClient(MollieApiClient $client);
+
+    /**
      * @param $orderId
-     * @return mixed
+     * @return Order
      */
     public function getOrder($orderId);
 
     /**
      * @param $paymentId
-     * @return mixed
+     * @return Payment
      */
     public function getPayment($paymentId);
 

--- a/Models/Transaction.php
+++ b/Models/Transaction.php
@@ -27,6 +27,13 @@ class Transaction
     private $transactionId;
 
     /**
+     * @return int
+     *
+     * @ORM\Column(name="shop_id", type="integer", nullable=true)
+     */
+    private $shopId;
+
+    /**
      * @var integer
      *
      * @ORM\Column(name="order_id", type="integer", nullable=true)
@@ -148,6 +155,8 @@ class Transaction
      */
     private $isShipped;
 
+
+
     public function getId()
     {
         return $this->id;
@@ -176,6 +185,22 @@ class Transaction
     public function setOrderId($orderId)
     {
         $this->orderId = $orderId;
+    }
+
+    /**
+     * @return int
+     */
+    public function getShopId()
+    {
+        return (int)$this->shopId;
+    }
+
+    /**
+     * @param int $shopId
+     */
+    public function setShopId($shopId)
+    {
+        $this->shopId = $shopId;
     }
 
     public function getOrderNumber()

--- a/Models/TransactionRepository.php
+++ b/Models/TransactionRepository.php
@@ -9,43 +9,6 @@ use Shopware\Models\Order\Order;
 
 class TransactionRepository extends ModelRepository
 {
-    /**
-     * Create a new transaction for the given order with the given
-     * mollie Order object. This stores the mollie ID with the
-     * order so it can be recovered later.
-     *
-     * @param Order|null $order
-     * @param \Mollie\Api\Resources\Order|null $mollieOrder
-     * @param \Mollie\Api\Resources\Payment|null $molliePayment
-     *
-     * @return \MollieShopware\Models\Transaction
-     * @throws \Exception
-     *
-     */
-    public function create(Order $order = null, $mollieOrder = null, $molliePayment = null)
-    {
-        $transaction = new Transaction();
-        $transactionId = $this->getLastId() + 1;
-
-        if (!empty($transaction)) {
-            $transaction->setId($transactionId);
-            $transaction->setTransactionId('mollie_' . $transactionId);
-            $transaction->setSessionId(\Enlight_Components_Session::getId());
-
-            if (!empty($order))
-                $transaction->setOrderId($order->getId());
-
-            if (!empty($mollieOrder))
-                $transaction->setMollieId($mollieOrder->id);
-
-            if (!empty($molliePayment))
-                $transaction->setMolliePaymentId($molliePayment->id);
-
-            $this->save($transaction);
-        }
-
-        return $transaction;
-    }
 
     /**
      * @param Transaction $transaction
@@ -57,7 +20,7 @@ class TransactionRepository extends ModelRepository
     {
         $this->getEntityManager()->persist($transaction);
         $this->getEntityManager()->flush($transaction);
-            
+
         return $transaction;
     }
 

--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -38,7 +38,7 @@
             <tag name="console.command"/>
             <argument type="service" id="mollie_shopware.config"/>
             <argument type="service" id="models"/>
-            <argument type="service" id="mollie_shopware.api"/>
+            <argument type="service" id="mollie_shopware.gateways.mollie"/>
             <argument type="service" id="mollie_shopware.components.logger"/>
         </service>
 


### PR DESCRIPTION
the idea of this PR was just a simple one, it ended a bit different :D  

the klrana shipping CLI just makes sure to go though all orders that are not shipped in Shopware and ship it, if a specific order status is set for an order.
there are different checks like "is order existing", "is already shipped" and more.

Unfortunately due to the  checkout flow design, it can be that an order is NOT existing, which is totally fine because the payment failed...thats why its not existing.
the previous code did add a log entry which caused problems for merchants....and also it got retried over and over again...

its not possible to check for a failed order with the shopware data without a real order :)
but its possible to ask mollie for their order data and get that data.
so if Mollie says its not valid -> i simply mark it as processed and then its fine

however...asking mollie without an order is not possible because every subshop can have a different API key in the plugin config, which means i would need the shop ID...but i dont have it without an order.
so i've extended the transaction table with a shop ID that is filled when starting a checkout.

now this is finally possible
================================

1. Check Mollie data and verifiy if the payment failed, or if its already shipped
2. if that was fine, verify data integrity and show errors if the order does still not exist for a valid payment
3. verify order status values to either ship or skip shipping

the code is backward compatible to transactions that do not have a shopId yet

also....i tried to do it as tight as possible,
but i only did private functions for now..there will be another feature to reuse that code 
and then we'll put it to a component with that PR

