### PR TITLE
MOL-115: Paid Order Status was not updated in Payments API

### DIFF
--- a/Components/Constants/PaymentStatus.php
+++ b/Components/Constants/PaymentStatus.php
@@ -7,7 +7,7 @@ class PaymentStatus
     const MOLLIE_PAYMENT_COMPLETED = 'completed';
     const MOLLIE_PAYMENT_PAID = 'paid';
     const MOLLIE_PAYMENT_AUTHORIZED = 'authorized';
-    const MOLLIE_PAYMENT_DELAYED = 'pending';
+    const MOLLIE_PAYMENT_PENDING = 'pending';
     const MOLLIE_PAYMENT_OPEN = 'open';
     const MOLLIE_PAYMENT_CANCELED = 'canceled';
     const MOLLIE_PAYMENT_EXPIRED = 'expired';
@@ -56,7 +56,7 @@ class PaymentStatus
         $list = [
             PaymentStatus::MOLLIE_PAYMENT_PAID,
             PaymentStatus::MOLLIE_PAYMENT_AUTHORIZED,
-            PaymentStatus::MOLLIE_PAYMENT_DELAYED,
+            PaymentStatus::MOLLIE_PAYMENT_PENDING,
             PaymentStatus::MOLLIE_PAYMENT_OPEN,
         ];
 

--- a/Components/Helpers/MollieStatusConverter.php
+++ b/Components/Helpers/MollieStatusConverter.php
@@ -118,7 +118,7 @@ class MollieStatusConverter
         } elseif ($payment->isPaid()) {
             $targetState = PaymentStatus::MOLLIE_PAYMENT_PAID;
         } elseif ($payment->isPending()) {
-            $targetState = PaymentStatus::MOLLIE_PAYMENT_DELAYED;
+            $targetState = PaymentStatus::MOLLIE_PAYMENT_PENDING;
         } elseif ($payment->isAuthorized()) {
             $targetState = PaymentStatus::MOLLIE_PAYMENT_AUTHORIZED;
         } elseif ($payment->isOpen()) {

--- a/Components/Services/PaymentService.php
+++ b/Components/Services/PaymentService.php
@@ -572,7 +572,7 @@ class PaymentService
             'total' => 0,
             PaymentStatus::MOLLIE_PAYMENT_PAID => 0,
             PaymentStatus::MOLLIE_PAYMENT_AUTHORIZED => 0,
-            PaymentStatus::MOLLIE_PAYMENT_DELAYED => 0,
+            PaymentStatus::MOLLIE_PAYMENT_PENDING => 0,
             PaymentStatus::MOLLIE_PAYMENT_OPEN => 0,
             PaymentStatus::MOLLIE_PAYMENT_CANCELED => 0,
             PaymentStatus::MOLLIE_PAYMENT_FAILED => 0,
@@ -593,7 +593,7 @@ class PaymentService
                     $paymentsResult[PaymentStatus::MOLLIE_PAYMENT_AUTHORIZED]++;
                 }
                 if ($payment->isPending()) {
-                    $paymentsResult[PaymentStatus::MOLLIE_PAYMENT_DELAYED]++;
+                    $paymentsResult[PaymentStatus::MOLLIE_PAYMENT_PENDING]++;
                 }
                 if ($payment->isOpen()) {
                     $paymentsResult[PaymentStatus::MOLLIE_PAYMENT_OPEN]++;

--- a/Components/StatusConverter/DataStruct/StatusTransactionStruct.php
+++ b/Components/StatusConverter/DataStruct/StatusTransactionStruct.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace MollieShopware\Components\StatusConverter\DataStruct;
+
+
+class StatusTransactionStruct
+{
+    /**
+     * @var int|null
+     */
+    private $targetStatus;
+
+    /**
+     * @var bool
+     */
+    private $ignoreState;
+
+    public function __construct($targetStatus, $ignoreState)
+    {
+        $this->targetStatus = $targetStatus;
+        $this->ignoreState = $ignoreState;
+    }
+
+    public function getTargetStatus()
+    {
+        return $this->targetStatus;
+    }
+
+    public function setTargetStatus($targetStatus)
+    {
+        $this->targetStatus = $targetStatus;
+    }
+
+    public function isIgnoreState()
+    {
+        return $this->ignoreState;
+    }
+
+    public function setIgnoreState($ignoreState)
+    {
+        $this->ignoreState = $ignoreState;
+    }
+}

--- a/Components/StatusConverter/OrderStatusConverter.php
+++ b/Components/StatusConverter/OrderStatusConverter.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace MollieShopware\Components\StatusConverter;
+
+use MollieShopware\Components\Constants\PaymentStatus;
+use MollieShopware\Components\StatusConverter\DataStruct\StatusTransactionStruct;
+use MollieShopware\Exceptions\OrderStatusNotFoundException;
+use MollieShopware\Exceptions\PaymentStatusNotFoundException;
+use Shopware\Models\Order\Status;
+
+class OrderStatusConverter
+{
+
+
+    /**
+     * @param string $molliePaymentStatus
+     * @return StatusTransactionStruct
+     * @throws PaymentStatusNotFoundException
+     */
+    public function getShopwareOrderStatus($molliePaymentStatus)
+    {
+        $targetState = null;
+
+        switch ($molliePaymentStatus) {
+
+            case PaymentStatus::MOLLIE_PAYMENT_OPEN:
+                $targetState = Status::ORDER_STATE_OPEN;
+                break;
+
+            case PaymentStatus::MOLLIE_PAYMENT_PAID:
+            case PaymentStatus::MOLLIE_PAYMENT_COMPLETED:
+                $targetState = Status::ORDER_STATE_COMPLETED;
+                break;
+
+            case PaymentStatus::MOLLIE_PAYMENT_CANCELED:
+            case PaymentStatus::MOLLIE_PAYMENT_FAILED:
+            case PaymentStatus::MOLLIE_PAYMENT_EXPIRED:
+                $targetState = Status::ORDER_STATE_CANCELLED_REJECTED;
+                break;
+
+            case PaymentStatus::MOLLIE_PAYMENT_PENDING:
+            case PaymentStatus::MOLLIE_PAYMENT_AUTHORIZED:
+            case PaymentStatus::MOLLIE_PAYMENT_REFUNDED:
+            case PaymentStatus::MOLLIE_PAYMENT_PARTIALLY_REFUNDED:
+                break;
+
+            default:
+                throw new PaymentStatusNotFoundException('Unable to get Shopware Order Status for Mollie Payment Status: ' . $molliePaymentStatus);
+        }
+
+
+        $ignoreState = ($targetState === null);
+
+        return new StatusTransactionStruct($targetState, $ignoreState);
+    }
+}

--- a/Components/StatusConverter/PaymentStatusConverter.php
+++ b/Components/StatusConverter/PaymentStatusConverter.php
@@ -1,0 +1,81 @@
+<?php
+
+
+namespace MollieShopware\Components\StatusConverter;
+
+
+use MollieShopware\Components\Constants\PaymentStatus;
+use MollieShopware\Components\StatusConverter\DataStruct\StatusTransactionStruct;
+use MollieShopware\Exceptions\PaymentStatusNotFoundException;
+use Shopware\Models\Order\Status;
+
+
+class PaymentStatusConverter
+{
+
+    /**
+     * @var int
+     */
+    private $authorizedPaymentStatus;
+
+
+    /**
+     * PaymentTransactionMapper constructor.
+     * @param int $authorizedPaymentStatus
+     */
+    public function __construct(int $authorizedPaymentStatus)
+    {
+        $this->authorizedPaymentStatus = $authorizedPaymentStatus;
+    }
+
+
+    /**
+     * @param $molliePaymentStatus
+     * @return StatusTransactionStruct
+     * @throws PaymentStatusNotFoundException
+     */
+    public function getShopwarePaymentStatus($molliePaymentStatus)
+    {
+        $targetState = null;
+
+        switch ($molliePaymentStatus) {
+
+            case PaymentStatus::MOLLIE_PAYMENT_OPEN:
+                $targetState = Status::PAYMENT_STATE_OPEN;
+                break;
+
+            case PaymentStatus::MOLLIE_PAYMENT_PENDING:
+                $targetState = Status::PAYMENT_STATE_DELAYED;
+                break;
+
+            case PaymentStatus::MOLLIE_PAYMENT_AUTHORIZED:
+                $targetState = $this->authorizedPaymentStatus;
+                break;
+
+            case PaymentStatus::MOLLIE_PAYMENT_PAID:
+            case PaymentStatus::MOLLIE_PAYMENT_COMPLETED:
+                $targetState = Status::PAYMENT_STATE_COMPLETELY_PAID;
+                break;
+
+            case PaymentStatus::MOLLIE_PAYMENT_EXPIRED:
+            case PaymentStatus::MOLLIE_PAYMENT_CANCELED:
+            case PaymentStatus::MOLLIE_PAYMENT_FAILED:
+                $targetState = Status::PAYMENT_STATE_THE_PROCESS_HAS_BEEN_CANCELLED;
+                break;
+
+            case PaymentStatus::MOLLIE_PAYMENT_REFUNDED:
+            case PaymentStatus::MOLLIE_PAYMENT_PARTIALLY_REFUNDED:
+                $targetState = Status::PAYMENT_STATE_RE_CREDITING;
+                break;
+
+            default:
+                throw new PaymentStatusNotFoundException('Unable to get Shopware Payment Status for Mollie Payment Status: ' . $molliePaymentStatus);
+        }
+
+
+        $ignoreState = ($targetState === null);
+
+        return new StatusTransactionStruct($targetState, $ignoreState);
+    }
+
+}

--- a/Tests/PHPUnit/Components/StatusConverter/OrderStatusConverterTest.php
+++ b/Tests/PHPUnit/Components/StatusConverter/OrderStatusConverterTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace MollieShopware\Tests\Components\StatusConverter;
+
+use MollieShopware\Components\Constants\PaymentStatus;
+use MollieShopware\Components\StatusConverter\OrderStatusConverter;
+use PHPUnit\Framework\TestCase;
+use Shopware\Models\Order\Status;
+
+
+class OrderStatusConverterTest extends TestCase
+{
+
+    /**
+     * This test verifies that our Mollie Payment status is
+     * correctly converted into the matching Shopware Order Status
+     * Here are overviews about the status changes in Mollie:
+     * - https://docs.mollie.com/payments/status-changes
+     * - https://docs.mollie.com/orders/status-changes
+     *
+     * @dataProvider getStatusMappings
+     * @covers       \MollieShopware\Components\StatusConverter\OrderStatusConverter::getShopwareOrderStatus
+     *
+     * @param $status
+     * @param $expectedStatus
+     * @throws \MollieShopware\Exceptions\OrderStatusNotFoundException
+     */
+    public function testStatusMapping($status, $expectedStatus)
+    {
+        $mapper = new OrderStatusConverter();
+
+        $result = $mapper->getShopwareOrderStatus($status);
+
+        # if we have no target state, that means we
+        # just ignore that state
+        $expectedIgnoreState = ($expectedStatus === null);
+
+        $this->assertEquals($expectedStatus, $result->getTargetStatus());
+        $this->assertEquals($expectedIgnoreState, $result->isIgnoreState());
+    }
+
+    /**
+     * @return array[]
+     */
+    public function getStatusMappings()
+    {
+        return [
+            'mollie_open' => [PaymentStatus::MOLLIE_PAYMENT_OPEN, Status::ORDER_STATE_OPEN],
+            'mollie_pending' => [PaymentStatus::MOLLIE_PAYMENT_PENDING, null],
+            'mollie_authorized' => [PaymentStatus::MOLLIE_PAYMENT_AUTHORIZED, null],
+            # ------------------------------------------------------------------------------------------------------
+            'mollie_paid' => [PaymentStatus::MOLLIE_PAYMENT_PAID, Status::ORDER_STATE_COMPLETED],
+            'mollie_completed' => [PaymentStatus::MOLLIE_PAYMENT_COMPLETED, Status::ORDER_STATE_COMPLETED],
+            # ------------------------------------------------------------------------------------------------------
+            'mollie_canceled' => [PaymentStatus::MOLLIE_PAYMENT_CANCELED, Status::ORDER_STATE_CANCELLED_REJECTED],
+            'mollie_failed' => [PaymentStatus::MOLLIE_PAYMENT_FAILED, Status::ORDER_STATE_CANCELLED_REJECTED],
+            'mollie_expired' => [PaymentStatus::MOLLIE_PAYMENT_EXPIRED, Status::ORDER_STATE_CANCELLED_REJECTED],
+            # ------------------------------------------------------------------------------------------------------
+            'mollie_refunded' => [PaymentStatus::MOLLIE_PAYMENT_REFUNDED, null],
+            'mollie_partially_refunded' => [PaymentStatus::MOLLIE_PAYMENT_PARTIALLY_REFUNDED, null],
+        ];
+    }
+
+}

--- a/Tests/PHPUnit/Components/StatusConverter/PaymentStatusConverterTest.php
+++ b/Tests/PHPUnit/Components/StatusConverter/PaymentStatusConverterTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace MollieShopware\Tests\Components\StatusConverter;
+
+use MollieShopware\Components\Constants\PaymentStatus;
+use MollieShopware\Components\StatusConverter\PaymentStatusConverter;
+use PHPUnit\Framework\TestCase;
+use Shopware\Models\Order\Status;
+
+
+class PaymentStatusConverterTest extends TestCase
+{
+
+    /**
+     *
+     */
+    public const CUSTOM_STATUS_AUTHORIZED = 99;
+
+
+    /**
+     * This test verifies that our Mollie Payment status is
+     * correctly converted into the matching Shopware Payment Status
+     * Here are overviews about the status changes in Mollie:
+     * - https://docs.mollie.com/payments/status-changes
+     * - https://docs.mollie.com/orders/status-changes
+     *
+     * @dataProvider getStatusMappings
+     * @covers       \MollieShopware\Components\StatusConverter\PaymentStatusConverter::getShopwarePaymentStatus
+     *
+     * @param $status
+     * @param $expectedStatus
+     * @throws \MollieShopware\Exceptions\PaymentStatusNotFoundException
+     */
+    public function testStatusMapping($status, $expectedStatus)
+    {
+        $converter = new PaymentStatusConverter(self::CUSTOM_STATUS_AUTHORIZED);
+
+        $result = $converter->getShopwarePaymentStatus($status);
+
+        # if we have no target state, that means we
+        # just ignore that state
+        $expectedIgnoreState = ($expectedStatus === null);
+
+        $this->assertEquals($expectedStatus, $result->getTargetStatus());
+        $this->assertEquals($expectedIgnoreState, $result->isIgnoreState());
+    }
+
+    /**
+     * @return array[]
+     */
+    public function getStatusMappings()
+    {
+        return [
+            'mollie_open' => [PaymentStatus::MOLLIE_PAYMENT_OPEN, Status::PAYMENT_STATE_OPEN],
+            'mollie_pending' => [PaymentStatus::MOLLIE_PAYMENT_PENDING, Status::PAYMENT_STATE_DELAYED],
+            'mollie_authorized' => [PaymentStatus::MOLLIE_PAYMENT_AUTHORIZED, self::CUSTOM_STATUS_AUTHORIZED],
+            # ------------------------------------------------------------------------------------------------------
+            'mollie_paid' => [PaymentStatus::MOLLIE_PAYMENT_PAID, Status::PAYMENT_STATE_COMPLETELY_PAID],
+            'mollie_completed' => [PaymentStatus::MOLLIE_PAYMENT_COMPLETED, Status::PAYMENT_STATE_COMPLETELY_PAID],
+            # ------------------------------------------------------------------------------------------------------
+            'mollie_canceled' => [PaymentStatus::MOLLIE_PAYMENT_CANCELED, Status::PAYMENT_STATE_THE_PROCESS_HAS_BEEN_CANCELLED],
+            'mollie_failed' => [PaymentStatus::MOLLIE_PAYMENT_FAILED, Status::PAYMENT_STATE_THE_PROCESS_HAS_BEEN_CANCELLED],
+            'mollie_expired' => [PaymentStatus::MOLLIE_PAYMENT_EXPIRED, Status::PAYMENT_STATE_THE_PROCESS_HAS_BEEN_CANCELLED],
+            # ------------------------------------------------------------------------------------------------------
+            'mollie_refunded' => [PaymentStatus::MOLLIE_PAYMENT_REFUNDED, Status::PAYMENT_STATE_RE_CREDITING],
+            'mollie_partially_refunded' => [PaymentStatus::MOLLIE_PAYMENT_PARTIALLY_REFUNDED, Status::PAYMENT_STATE_RE_CREDITING],
+        ];
+    }
+
+}


### PR DESCRIPTION
add missing mapping for status "paid" in payments api
so both "paid" and "completed" will now lead to an order status COMPLETED

i did also encapsulate the mappings into unit tested converters for both
the payment status and order status

so our unit tests do no provide a good overview, on WHAT is being used WHEN