### PR TITLE
MOL-431: Fix missing Open status in Orders API

### DIFF
--- a/Components/Helpers/MollieStatusConverter.php
+++ b/Components/Helpers/MollieStatusConverter.php
@@ -51,6 +51,10 @@ class MollieStatusConverter
                 $targetStatus = PaymentStatus::MOLLIE_PAYMENT_PAID;
             }
 
+            if ($paymentsResult[PaymentStatus::MOLLIE_PAYMENT_PENDING] == $paymentsResult['total']) {
+                $targetStatus = PaymentStatus::MOLLIE_PAYMENT_PENDING;
+            }
+
             // fully authorized
             if ($paymentsResult[PaymentStatus::MOLLIE_PAYMENT_AUTHORIZED] == $paymentsResult['total']) {
                 $targetStatus = PaymentStatus::MOLLIE_PAYMENT_AUTHORIZED;
@@ -76,6 +80,8 @@ class MollieStatusConverter
         } else {
             if ($order->isPaid()) {
                 $targetStatus = PaymentStatus::MOLLIE_PAYMENT_PAID;
+            } elseif ($order->isPending()) {
+                $targetStatus = PaymentStatus::MOLLIE_PAYMENT_PENDING;
             } elseif ($order->isAuthorized()) {
                 $targetStatus = PaymentStatus::MOLLIE_PAYMENT_AUTHORIZED;
             } elseif ($order->isCanceled()) {

--- a/Components/StatusConverter/OrderStatusConverter.php
+++ b/Components/StatusConverter/OrderStatusConverter.php
@@ -45,7 +45,7 @@ class OrderStatusConverter
                 break;
 
             default:
-                throw new PaymentStatusNotFoundException('Unable to get Shopware Order Status for Mollie Payment Status: ' . $molliePaymentStatus);
+                throw new PaymentStatusNotFoundException('Unable to convert Mollie Payment Status: ' . $molliePaymentStatus . ' to Shopware Order Status!');
         }
 
 

--- a/Components/StatusConverter/PaymentStatusConverter.php
+++ b/Components/StatusConverter/PaymentStatusConverter.php
@@ -69,7 +69,7 @@ class PaymentStatusConverter
                 break;
 
             default:
-                throw new PaymentStatusNotFoundException('Unable to get Shopware Payment Status for Mollie Payment Status: ' . $molliePaymentStatus);
+                throw new PaymentStatusNotFoundException('Unable to convert Mollie Payment Status: ' . $molliePaymentStatus . ' to Shopware Payment Status!');
         }
 
 


### PR DESCRIPTION
the pending state was missing for the orders api

added, and its now working 

also renamed 2 exception because the same one is somewhere else (required)