### PR TITLE
MOL-456: Fix exception if previous order status is empty

### DIFF
--- a/Components/Order/OrderUpdater.php
+++ b/Components/Order/OrderUpdater.php
@@ -175,9 +175,14 @@ class OrderUpdater
      */
     private function updateOrderHistoryComment(Order $order)
     {
-        /** @var History $lastEntry */
+        /** @var History|false $lastEntry */
         $lastEntry = $order->getHistory()->last();
 
+        if (!$lastEntry instanceof History) {
+            return;
+        }
+
+        # do not update previous comments
         if (!empty($lastEntry->getComment())) {
             return;
         }


### PR DESCRIPTION
somehow the transition is null in some cases for a merchant

added a condition to avoid at least an exception, still its weird