### PR TITLE
MOL-181: Payment Link in Shopware Backend

### DIFF
--- a/Gateways/Mollie/MollieGateway.php
+++ b/Gateways/Mollie/MollieGateway.php
@@ -5,6 +5,7 @@ namespace MollieShopware\Gateways\Mollie;
 use Mollie\Api\MollieApiClient;
 use Mollie\Api\Resources\Issuer;
 use Mollie\Api\Resources\Order;
+use Mollie\Api\Resources\Profile;
 use Mollie\Api\Resources\Shipment;
 use MollieShopware\Components\Constants\PaymentMethod;
 use MollieShopware\Facades\FinishCheckout\Services\MollieStatusValidator;
@@ -37,6 +38,49 @@ class MollieGateway implements MollieGatewayInterface
     public function switchClient(MollieApiClient $client)
     {
         $this->apiClient = $client;
+    }
+
+    /**
+     * @return string
+     * @throws \Mollie\Api\Exceptions\ApiException
+     */
+    public function getProfileId()
+    {
+        $profile = $this->apiClient->profiles->get('me');
+
+        if ($profile === null) {
+            return '';
+        }
+
+        return (string)$profile->id;
+    }
+
+    /**
+     * @return string
+     * @throws \Mollie\Api\Exceptions\ApiException
+     */
+    public function getOrganizationId()
+    {
+        $profile = $this->apiClient->profiles->get('me');
+
+        if ($profile === null) {
+            return '';
+        }
+
+        # the organization is in a full dashboard URL
+        # so we grab it, and extract that slug with the organization id
+        $orgId = (string)$profile->_links->dashboard->href;
+
+        $parts = explode('/', $orgId);
+
+        foreach ($parts as $part) {
+            if (strpos($part, 'org_') === 0) {
+                $orgId = $part;
+                break;
+            }
+        }
+
+        return (string)$orgId;
     }
 
     /**

--- a/Gateways/MollieGatewayInterface.php
+++ b/Gateways/MollieGatewayInterface.php
@@ -18,6 +18,16 @@ interface MollieGatewayInterface
     public function switchClient(MollieApiClient $client);
 
     /**
+     * @return string
+     */
+    public function getOrganizationId();
+
+    /**
+     * @return string
+     */
+    public function getProfileId();
+
+    /**
      * @param $orderId
      * @return Order
      */

--- a/Models/TransactionRepository.php
+++ b/Models/TransactionRepository.php
@@ -25,16 +25,14 @@ class TransactionRepository extends ModelRepository implements TransactionReposi
     }
 
     /**
-     * Get the most recent transaction for an order
-     *
-     * @param Order $order
-     * @return Transaction|null
+     * @param int $orderId
+     * @return Transaction
      */
-    public function getMostRecentTransactionForOrder(Order $order)
+    public function getTransactionByOrder($orderId)
     {
         /** @var Transaction $transaction */
         $transaction = $this->findOneBy([
-            'orderId' => $order->getId()
+            'orderId' => $orderId
         ]);
 
         return $transaction;

--- a/MollieShopware.php
+++ b/MollieShopware.php
@@ -137,6 +137,7 @@ class MollieShopware extends Plugin
             $view->extendsTemplate('backend/mollie_extend_order/view/list/list.js');
             $view->extendsTemplate('backend/mollie_extend_order/controller/list.js');
             $view->extendsTemplate('backend/mollie_extend_order/model/order_history.js');
+            $view->extendsTemplate('backend/mollie_extend_order/view/detail/overview.js');
             $view->extendsTemplate('backend/mollie_extend_order/view/detail/order-history.js');
             $view->extendsTemplate('backend/mollie_extend_order_detail/view/detail/position.js');
         }

--- a/Resources/snippets/backend/mollie/general.ini
+++ b/Resources/snippets/backend/mollie/general.ini
@@ -19,6 +19,16 @@ order_details_info_partialrefund_created = "The partial refund is successfully c
 order_details_confirm_refund_title = "Refund Order"
 order_details_confirm_refund_message = "Are you sure you want to refund the order? The pending refund can be cancelled in the Mollie Dashboard until executed (a few hours). Thus it takes a bit until the order is marked as refunded in Shopware!"
 
+order_details_overview_btn_open_payment = "Open Payment"
+order_details_overview_mode_caption = "Mode"
+order_details_overview_description_caption = "Description"
+order_details_overview_paymentstatus_caption = "Payment Status"
+order_details_overview_checkouturl_caption = "Checkout URL"
+order_details_overview_btn_copy = "Copy"
+order_details_overview_no_checkout_url = "No Checkout URL available"
+order_details_overview_growl_copy_alert = "Successfully copied"
+order_details_overview_growl_copy_message = "The text has been copied to your clipboard."
+
 
 [de_DE]
 global_error_order_already_shipped = "Bestellung bereits versendet"
@@ -41,6 +51,16 @@ order_details_info_partialrefund_created = "Die Teilrückerstattung wurde durchg
 order_details_confirm_refund_title = "Bestellung zurückerstatten"
 order_details_confirm_refund_message = "Möchtest du die Bestellung wirklich zurückerstatten? Da eine Rückerstattung für ein paar Stunden im Mollie Dashboard abgebrochen werden kann, dauert es eine Weile bis die Bestellung in Shopware als rückerstattet markiert wird."
 
+order_details_overview_btn_open_payment = "Zahlung öffnen"
+order_details_overview_mode_caption = "Modus"
+order_details_overview_description_caption = "Beschreibung"
+order_details_overview_paymentstatus_caption = "Zahlungstatus"
+order_details_overview_checkouturl_caption = "Zahlungs URL"
+order_details_overview_btn_copy = "Kopieren"
+order_details_overview_no_checkout_url = "Keine Zahlungs URL verfügbar"
+order_details_overview_growl_copy_alert = "Erfolgreich kopiert"
+order_details_overview_growl_copy_message = "Der Text wurde erfolgreich in die Zwischenablage kopiert."
+
 
 [nl_NL]
 global_error_order_already_shipped = "Bestelling al verzonden"
@@ -62,3 +82,13 @@ order_details_info_partialrefund_processing = "De gedeeltelijke terugbetaling wo
 order_details_info_partialrefund_created = " Het creëren van de gedeeltelijke terugbetaling is geslaagd"
 order_details_confirm_refund_title = "Bestelling terugbetalen"
 order_details_confirm_refund_message = "Ben je zeker dat je de bestelling wilt terugbetalen? Let op: Een terugbetaling wordt een paar uur als geannuleerd aangetoond in het Mollie Dashboard voordat het in Shopware als terugbetaald wordt gemarkeerd."
+
+order_details_overview_btn_open_payment = "Betaling openen"
+order_details_overview_mode_caption = "Mode"
+order_details_overview_description_caption = "Description"
+order_details_overview_paymentstatus_caption = "Betaalstatus"
+order_details_overview_checkouturl_caption = "Checkout URL"
+order_details_overview_btn_copy = "Kopieer"
+order_details_overview_no_checkout_url = "Geen Checkout URL beschikbaar"
+order_details_overview_growl_copy_alert = "Succesvol gekopieerd"
+order_details_overview_growl_copy_message = "De tekst is gekopieerd naar uw klembord."

--- a/Resources/views/backend/mollie_extend_order/view/detail/overview.js
+++ b/Resources/views/backend/mollie_extend_order/view/detail/overview.js
@@ -1,0 +1,279 @@
+// {block name="backend/order/view/detail/overview"}
+// {$smarty.block.parent}
+
+Ext.define('Shopware.apps.Mollie.Order.view.detail.Overview', {
+    override: 'Shopware.apps.Order.view.detail.Overview',
+
+    dashboardUrl: '',
+
+    molSnippets: {
+        captionMollieId: 'Mollie ID',
+        btnOpenPayment: '{s namespace="backend/mollie/general" name="order_details_overview_btn_open_payment"}{/s}',
+        captionMode: '{s namespace="backend/mollie/general" name="order_details_overview_mode_caption"}{/s}',
+        captionDescription: '{s namespace="backend/mollie/general" name="order_details_overview_description_caption"}{/s}',
+        captionPaymentStatus: '{s namespace="backend/mollie/general" name="order_details_overview_paymentstatus_caption"}{/s}',
+        captionCheckoutUrl: '{s namespace="backend/mollie/general" name="order_details_overview_checkouturl_caption"}{/s}',
+        btnCopyCaption: '{s namespace="backend/mollie/general" name="order_details_overview_btn_copy"}{/s}',
+        emptyCheckoutUrl: '{s namespace="backend/mollie/general" name="order_details_overview_no_checkout_url"}{/s}',
+        growlCopyTitle: '{s namespace="backend/mollie/general" name="order_details_overview_growl_copy_alert"}{/s}',
+        growlCopyMessage: '{s namespace="backend/mollie/general" name="order_details_overview_growl_copy_message"}{/s}'
+    },
+
+    initComponent: function () {
+        var me = this;
+
+        me.containerMollie = me.createMollieContainer();
+
+        me.callParent(arguments);
+
+        me.loadMollieData();
+    },
+
+    createToolbar: function () {
+        var me = this;
+
+        me.callParent();
+
+        me.items.splice(5, 0, me.containerMollie);
+
+        me.loadMollieData();
+
+        return me.toolbar;
+    },
+
+    loadMollieData() {
+        var me = this;
+
+        Ext.Ajax.request({
+            url: '{url controller=MollieOrders action="getMollieOrderData"}',
+            params: {
+                orderId: me.record.get('id')
+            },
+            success: function (res) {
+                try {
+
+                    var result = JSON.parse(res.responseText);
+
+                    if (!result.success) {
+                        throw new Error(result.message);
+                    }
+
+                    me.dashboardUrl = result.data.url;
+
+                    me.getFormField('mollie_id', field => {
+                        field.setValue(result.data.mollieId);
+                    });
+
+                    me.getFormField('mollie_mode', field => {
+                        field.setValue(result.data.mode);
+                    });
+
+                    me.getFormField('mollie_description', field => {
+                        field.setValue(result.data.description);
+                    });
+
+                    me.getFormField('mollie_payment_status', field => {
+                        field.setValue(result.data.paymentStatus);
+                    });
+
+                    me.getFormField('mollie_checkout_url', field => {
+                        field.setValue(result.data.checkoutUrl);
+                    });
+                } catch (e) {
+                    console.log(e);
+                }
+            }
+        });
+    },
+
+    createMollieContainer: function () {
+        var me = this;
+
+        const labelWidth = 155;
+
+        // padding: top right bot left
+
+        const rowId = {
+            xtype: 'fieldset',
+            flex: 12,
+            border: false,
+            margin: '0',
+            padding: '10 10 0 10',
+            bodyPadding: 0,
+            layout: 'hbox',
+            items: [
+                {
+                    xtype: 'textfield',
+                    flex: 8,
+                    name: 'mollie_id',
+                    fieldLabel: me.molSnippets.captionMollieId,
+                    labelWidth: labelWidth,
+                    readOnly: true,
+                },
+                {
+                    xtype: 'button',
+                    flex: 2,
+                    text: me.molSnippets.btnCopyCaption,
+                    cls: 'small primary',
+                    margin: '2 0 0 10',
+                    scope: this,
+                    handler: function () {
+                        me.getFormField('mollie_id', field => {
+                            navigator.clipboard.writeText(field.getValue());
+                            Shopware.Notification.createGrowlMessage(
+                                me.molSnippets.growlCopyTitle,
+                                me.molSnippets.growlCopyMessage,
+                                ''
+                            );
+                        });
+                    }
+                },
+                {
+                    xtype: 'button',
+                    flex: 2,
+                    text: me.molSnippets.btnOpenPayment,
+                    cls: 'small primary',
+                    margin: '2 0 0 10',
+                    scope: this,
+                    handler: function () {
+                        window.open(me.dashboardUrl, '_blank').focus();
+                    }
+                }
+            ]
+
+        };
+
+        const rowDescription = {
+            xtype: 'fieldset',
+            flex: 12,
+            border: false,
+            margin: '0',
+            padding: '5 10 0 10',
+            bodyPadding: 0,
+            layout: 'hbox',
+            items: [
+                {
+                    xtype: 'textfield',
+                    flex: 12,
+                    name: 'mollie_description',
+                    fieldLabel: me.molSnippets.captionDescription,
+                    labelWidth: labelWidth,
+                    readOnly: true,
+                }
+            ]
+        };
+
+        const rowMode = {
+            xtype: 'fieldset',
+            flex: 12,
+            border: false,
+            margin: '0',
+            padding: '5 10 0 10',
+            bodyPadding: 0,
+            layout: 'hbox',
+            items: [
+                {
+                    xtype: 'textfield',
+                    flex: 12,
+                    name: 'mollie_mode',
+                    fieldLabel: me.molSnippets.captionMode,
+                    labelWidth: labelWidth,
+                    readOnly: true,
+                }
+            ]
+        };
+
+        const rowPaymentStatus = {
+            xtype: 'fieldset',
+            flex: 12,
+            border: false,
+            margin: '0',
+            padding: '5 10 0 10',
+            bodyPadding: 0,
+            layout: 'hbox',
+            items: [
+                {
+                    xtype: 'textfield',
+                    flex: 12,
+                    name: 'mollie_payment_status',
+                    fieldLabel: me.molSnippets.captionPaymentStatus,
+                    labelWidth: labelWidth,
+                    readOnly: true,
+                }
+            ]
+        };
+
+        const rowCheckoutUrl = {
+            xtype: 'fieldset',
+            flex: 12,
+            border: false,
+            margin: '0',
+            padding: '5 10 10 10',
+            bodyPadding: 0,
+            layout: 'hbox',
+            items: [
+                {
+                    xtype: 'textfield',
+                    flex: 10,
+                    name: 'mollie_checkout_url',
+                    fieldLabel: me.molSnippets.captionCheckoutUrl,
+                    emptyText: me.molSnippets.emptyCheckoutUrl,
+                    labelWidth: labelWidth,
+                    readOnly: true,
+                },
+                {
+                    xtype: 'button',
+                    flex: 2,
+                    text: me.molSnippets.btnCopyCaption,
+                    cls: 'small primary',
+                    margin: '2 0 0 10',
+                    scope: this,
+                    handler: function () {
+                        me.getFormField('mollie_checkout_url', field => {
+
+                            navigator.clipboard.writeText(field.getValue());
+
+                            Shopware.Notification.createGrowlMessage(
+                                me.molSnippets.growlCopyTitle,
+                                me.molSnippets.growlCopyMessage,
+                                ''
+                            );
+                        });
+                    }
+                }
+            ]
+        };
+
+        return Ext.create('Ext.form.Panel', {
+            title: 'Mollie Details',
+            border: true,
+            bodyPadding: 0,
+            margin: '10 0 10 0',
+            padding: '0',
+            layout: 'anchor',
+            items: [
+                rowId,
+                rowDescription,
+                rowMode,
+                rowPaymentStatus,
+                rowCheckoutUrl
+            ]
+        });
+    },
+
+
+    getFormField(name, callback) {
+        var me = this;
+
+        var fields = me.containerMollie.getForm().getFields();
+
+        Ext.each(fields.items, function (field) {
+            if (field.name === name) {
+                callback(field);
+            }
+        });
+    }
+
+})
+;
+//{/block}


### PR DESCRIPTION
added new live preview of the mollie payment data in the shopware backend.

the orders detail overview has been extended with a new section
that shows data for the payment

the data will be fetched from a backend controller.

there are also 2 copy clipboard buttons and a deep-link button to open the payment in the mollie dashboard