### PR TITLE
MOL-489: Skip Klarna Paid Status Mails

### DIFF
--- a/Components/Config.php
+++ b/Components/Config.php
@@ -11,7 +11,7 @@ use Shopware\Models\Shop\Repository;
 use Shopware\Models\Shop\Shop;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
-class Config
+class Config implements ConfigInterface
 {
     const TRANSACTION_NUMBER_TYPE_MOLLIE = 'mollie';
     const TRANSACTION_NUMBER_TYPE_PAYMENT_METHOD = 'payment_method';

--- a/Components/ConfigInterface.php
+++ b/Components/ConfigInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace MollieShopware\Components;
+
+interface ConfigInterface
+{
+
+    /**
+     * @return boolean
+     */
+    public function isPaymentStatusMailEnabled();
+
+}

--- a/Components/Validator/PaymentStatusMailValidator.php
+++ b/Components/Validator/PaymentStatusMailValidator.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace MollieShopware\Components\Validator;
+
+use MollieShopware\Components\ConfigInterface;
+use MollieShopware\Components\Constants\PaymentMethod;
+use MollieShopware\Components\Constants\PaymentStatus;
+use MollieShopware\MollieShopware;
+use Shopware\Models\Order\Order;
+
+class PaymentStatusMailValidator
+{
+
+    /**
+     * @var ConfigInterface
+     */
+    private $config;
+
+
+    /**
+     * @param ConfigInterface $config
+     */
+    public function __construct(ConfigInterface $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * @param Order $order
+     * @param string $mollieStatus
+     * @return bool
+     */
+    public function shouldSendPaymentStatusMail(Order $order, $mollieStatus)
+    {
+        # if our order uses klarna, then verify if its transition is "paid".
+        # This means that it's paid for the merchant and in Mollie, but it does NOT mean
+        # that the customer paid the amount to Klarna.
+        # In this case we always skip payment status emails, because it would confuse the customer
+        if ($order->getPayment()->getName() === MollieShopware::PAYMENT_PREFIX . PaymentMethod::KLARNA_PAY_LATER) {
+
+            if ($mollieStatus === PaymentStatus::MOLLIE_PAYMENT_PAID) {
+                return false;
+            }
+
+            if ($mollieStatus === PaymentStatus::MOLLIE_PAYMENT_COMPLETED) {
+                return false;
+            }
+        }
+
+        return $this->config->isPaymentStatusMailEnabled();
+    }
+
+}

--- a/Tests/PHPUnit/Components/Validator/PaymentStatusMailValidatorTest.php
+++ b/Tests/PHPUnit/Components/Validator/PaymentStatusMailValidatorTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace MollieShopware\Tests\Components\Validator;
+
+
+use MollieShopware\Components\Constants\PaymentMethod;
+use MollieShopware\Components\Constants\PaymentStatus;
+use MollieShopware\Components\Validator\PaymentStatusMailValidator;
+use MollieShopware\MollieShopware;
+use MollieShopware\Tests\Utils\Fakes\Config\FakeConfig;
+use PHPUnit\Framework\TestCase;
+use Shopware\Models\Order\Order;
+
+use Shopware\Models\Order\Status;
+use Shopware\Models\Payment\Payment;
+
+class PaymentStatusMailValidatorTest extends TestCase
+{
+
+    /**
+     * @var Order
+     */
+    private $order;
+
+
+    /**
+     *
+     */
+    public function setUp(): void
+    {
+        $status = new Status();
+        $status->setName('authorized');
+
+        $payment = new Payment();
+        $payment->setName(MollieShopware::PAYMENT_PREFIX . PaymentMethod::PAYPAL);
+
+        $this->order = new Order();
+        $this->order->setPayment($payment);
+        $this->order->setPaymentStatus($status);
+    }
+
+    /**
+     * This test verifies that we always send a mail if its configured.
+     * No matter what status is set, it should be sent.
+     */
+    public function testSendIfConfigured()
+    {
+        $config = new FakeConfig(true);
+        $validator = new PaymentStatusMailValidator($config);
+
+        $this->order->getPaymentStatus()->setName('something');
+
+        $sendMail = $validator->shouldSendPaymentStatusMail($this->order, 'something-else');
+
+        $this->assertEquals(true, $sendMail);
+    }
+
+    /**
+     * This test verifies that we do not send mails if its not configured.
+     * No matter what status is set, it should be sent.
+     */
+    public function testDontSendIfConfigured()
+    {
+        $config = new FakeConfig(false);
+        $validator = new PaymentStatusMailValidator($config);
+
+        $this->order->getPaymentStatus()->setName('something');
+
+        $sendMail = $validator->shouldSendPaymentStatusMail($this->order, 'something-else');
+
+        $this->assertEquals(false, $sendMail);
+    }
+
+    /**
+     * This test verifies that we do not send klarna mails that are "paid".
+     * The mail would be configured, but the customer did not really pay Klarna at that time.
+     * Only Mollie has that status, so this would confuse the customer.
+     */
+    public function testDontSendPaidKlarna()
+    {
+        $config = new FakeConfig(true);
+        $validator = new PaymentStatusMailValidator($config);
+
+        $this->order->getPayment()->setName(MollieShopware::PAYMENT_PREFIX . PaymentMethod::KLARNA_PAY_LATER);
+        $this->order->getPaymentStatus()->setName('authorized');
+
+        $sendMail = $validator->shouldSendPaymentStatusMail($this->order, PaymentStatus::MOLLIE_PAYMENT_PAID);
+
+        $this->assertEquals(false, $sendMail);
+    }
+
+    /**
+     * This test verifies that we do not send klarna mails that are "completed".
+     * The mail would be configured, but the customer did not really pay Klarna at that time.
+     * Only Mollie has that status, so this would confuse the customer.
+     */
+    public function testDontSendCompletedKlarna()
+    {
+        $config = new FakeConfig(true);
+        $validator = new PaymentStatusMailValidator($config);
+
+        $this->order->getPayment()->setName(MollieShopware::PAYMENT_PREFIX . PaymentMethod::KLARNA_PAY_LATER);
+        $this->order->getPaymentStatus()->setName('authorized');
+
+        $sendMail = $validator->shouldSendPaymentStatusMail($this->order, PaymentStatus::MOLLIE_PAYMENT_COMPLETED);
+
+        $this->assertEquals(false, $sendMail);
+    }
+
+    /**
+     * This test verifies that we send klarna mails that are something else than paid or completed.
+     * This means, that Klarna mails should still work for all other cases.
+     */
+    public function testSendAnyOtherKlarna()
+    {
+        $config = new FakeConfig(true);
+        $validator = new PaymentStatusMailValidator($config);
+
+        $this->order->getPayment()->setName(MollieShopware::PAYMENT_PREFIX . PaymentMethod::KLARNA_PAY_LATER);
+        $this->order->getPaymentStatus()->setName('paid');
+
+        $sendMail = $validator->shouldSendPaymentStatusMail($this->order, PaymentStatus::MOLLIE_PAYMENT_REFUNDED);
+
+        $this->assertEquals(true, $sendMail);
+    }
+
+}

--- a/Tests/PHPUnit/Utils/Fakes/Config/FakeConfig.php
+++ b/Tests/PHPUnit/Utils/Fakes/Config/FakeConfig.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace MollieShopware\Tests\Utils\Fakes\Config;
+
+use MollieShopware\Components\ConfigInterface;
+
+
+class FakeConfig implements ConfigInterface
+{
+
+    /**
+     * @var bool
+     */
+    private $paymentStatusMail;
+
+
+    /**
+     * @param bool $paymentStatusMail
+     */
+    public function __construct(bool $paymentStatusMail)
+    {
+        $this->paymentStatusMail = $paymentStatusMail;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isPaymentStatusMailEnabled()
+    {
+        return $this->paymentStatusMail;
+    }
+
+}


### PR DESCRIPTION
if payment status mails are enabled, the customer gets a paid-mail when mollie sends "paid" or completed for klarna.

the problem is, that this is only between the merchant and mollie.

the customer himself did not pay to klarna yet.

this mail would confuse him, so we make sure to always skip it