### PR TITLE
WIP: MOL-493: Remove Klarna Shipped Status Configuration

### DIFF
--- a/Components/Config.php
+++ b/Components/Config.php
@@ -332,15 +332,7 @@ class Config implements ConfigInterface
     {
         return (int)$this->get('klarna_ship_on_status', Status::ORDER_STATE_COMPLETELY_DELIVERED);
     }
-
-    /**
-     * @return int
-     */
-    public function getShippedStatus()
-    {
-        return (int)$this->get('klarna_shipped_status', -1);
-    }
-
+    
     /**
      * @return string
      */

--- a/Controllers/Backend/MollieOrders.php
+++ b/Controllers/Backend/MollieOrders.php
@@ -252,14 +252,6 @@ class Shopware_Controllers_Backend_MollieOrders extends Shopware_Controllers_Bac
 
                 $transaction->setIsShipped(true);
 
-                if ((int)$this->config->getShippedStatus() > 0) {
-                    Shopware()->Modules()->Order()->setOrderStatus(
-                        $order->getId(),
-                        $this->config->getShippedStatus(),
-                        $this->config->isPaymentStatusMailEnabled()
-                    );
-                }
-
                 $this->modelManager->flush($transaction);
 
                 $this->returnSuccess('Order status set to shipped at Mollie', true);

--- a/Resources/config.xml
+++ b/Resources/config.xml
@@ -577,37 +577,12 @@
         </element>
 
         <element type="button" required="false">
-            <name>separator_klarna</name>
-            <label lang="de">--------------------------------------------------------------------------------------- Klarna ---------------------------------------------------------------------------------------</label>
-            <label lang="en">--------------------------------------------------------------------------------------- Klarna ---------------------------------------------------------------------------------------</label>
-            <label lang="nl">--------------------------------------------------------------------------------------- Klarna ---------------------------------------------------------------------------------------</label>
-            <options>
-                <position>23</position>
-            </options>
-        </element>
-
-
-        <element type="combo" scope="shop">
-            <name>klarna_shipped_status</name>
-            <label lang="de">Status für versendete Bestellungen</label>
-            <label lang="en">Status for shipped orders</label>
-            <label lang="nl">Status voor verzonden bestellingen</label>
-            <description lang="de">Bestellstatus für Bestellungen die als versendet markiert wurden.</description>
-            <description lang="en">Order status for shipped orders.</description>
-            <description lang="nl">Bestelstatus voor bestellingen die zijn gemarkeerd als verzonden</description>
-            <store>Shopware.apps.Base.store.OrderStatus</store>
-            <options>
-                <position>24</position>
-            </options>
-        </element>
-
-        <element type="button" required="false">
             <name>separator_applepay</name>
             <label lang="de">--------------------------------------------------------------------------------------- Apple Pay ---------------------------------------------------------------------------------------</label>
             <label lang="en">--------------------------------------------------------------------------------------- Apple Pay ---------------------------------------------------------------------------------------</label>
             <label lang="nl">--------------------------------------------------------------------------------------- Apple Pay ---------------------------------------------------------------------------------------</label>
             <options>
-                <position>25</position>
+                <position>23</position>
             </options>
         </element>
 
@@ -648,7 +623,7 @@
                 <valueField>id</valueField>
                 <displayField>name</displayField>
                 <isCustomStore>true</isCustomStore>
-                <position>26</position>
+                <position>24</position>
             </options>
         </element>
 
@@ -658,7 +633,7 @@
             <label lang="en">--------------------------------------------------------------------------------------- Bank Transfer ---------------------------------------------------------------------------------------</label>
             <label lang="nl">--------------------------------------------------------------------------------------- Bank Transfer ---------------------------------------------------------------------------------------</label>
             <options>
-                <position>27</position>
+                <position>25</position>
             </options>
         </element>
 
@@ -668,7 +643,7 @@
             <label lang="en">Payment term (Days)</label>
             <label lang="nl">Betalingstermijn (Dagen)</label>
             <options>
-                <position>28</position>
+                <position>26</position>
             </options>
         </element>
 


### PR DESCRIPTION
this function did only update the order status to shipped when doing a manual shipping in shopware.

it doesnt work in other shipping ways though

and also, if the update order status feature is activated, it will be overwritten anyway with the incoming webhook