### PR TITLE
NTR: improve exception handling when shipping orders

### DIFF
--- a/Components/Services/PaymentService.php
+++ b/Components/Services/PaymentService.php
@@ -507,17 +507,10 @@ class PaymentService
                 }
             }
 
-            try {
 
-                $mollieShipping = new MollieShipping($this->gwMollie);
+            $mollieShipping = new MollieShipping($this->gwMollie);
 
-                $result = $mollieShipping->shipOrder($shopwareOrder, $mollieOrder);
-
-            } catch (\Exception $ex) {
-                throw new \Exception('The order can\'t be shipped.');
-            }
-
-            return $result;
+            return $mollieShipping->shipOrder($shopwareOrder, $mollieOrder);
         }
 
         return false;


### PR DESCRIPTION
removed the exception catching that throws a new exception with a useless message :)
just removed it to really get errors immediately including the correct text