### PR TITLE
MOL-499: Support additional tracking variables in shipments

### DIFF
--- a/Command/KlarnaShippingCommand.php
+++ b/Command/KlarnaShippingCommand.php
@@ -39,13 +39,15 @@ class KlarnaShippingCommand extends ShopwareCommand
 
 
     /**
+     * KlarnaShippingCommand constructor.
      * @param Config $config
      * @param ModelManager $modelManager
+     * @param \Enlight_Template_Manager $smarty
      * @param MollieGatewayInterface $gwMollie
      * @param LoggerInterface $logger
      * @param null $name
      */
-    public function __construct(Config $config, ModelManager $modelManager, MollieGatewayInterface $gwMollie, LoggerInterface $logger, $name = null)
+    public function __construct(Config $config, ModelManager $modelManager, \Enlight_Template_Manager $smarty, MollieGatewayInterface $gwMollie, LoggerInterface $logger, $name = null)
     {
         parent::__construct($name);
 
@@ -57,7 +59,7 @@ class KlarnaShippingCommand extends ShopwareCommand
             self::LOG_PREFIX,
             $config,
             $gwMollie,
-            new MollieShipping($gwMollie),
+            new MollieShipping($gwMollie, $smarty),
             new MollieStatusValidator(),
             $logger,
             $repoShops,

--- a/Command/ShippingCommand.php
+++ b/Command/ShippingCommand.php
@@ -38,13 +38,15 @@ class ShippingCommand extends ShopwareCommand
 
 
     /**
+     * ShippingCommand constructor.
      * @param Config $config
      * @param ModelManager $modelManager
+     * @param \Enlight_Template_Manager $smarty
      * @param MollieGatewayInterface $gwMollie
      * @param LoggerInterface $logger
      * @param null $name
      */
-    public function __construct(Config $config, ModelManager $modelManager, MollieGatewayInterface $gwMollie, LoggerInterface $logger, $name = null)
+    public function __construct(Config $config, ModelManager $modelManager, \Enlight_Template_Manager $smarty, MollieGatewayInterface $gwMollie, LoggerInterface $logger, $name = null)
     {
         parent::__construct($name);
 
@@ -58,7 +60,7 @@ class ShippingCommand extends ShopwareCommand
             self::LOG_PREFIX,
             $config,
             $gwMollie,
-            new MollieShipping($gwMollie),
+            new MollieShipping($gwMollie, $smarty),
             new MollieStatusValidator(),
             $logger,
             $repoShops,

--- a/Components/Mollie/MollieShipping.php
+++ b/Components/Mollie/MollieShipping.php
@@ -10,22 +10,25 @@ class MollieShipping
 {
 
     /**
-     * Shopware tracking code variable of order.
-     */
-    const TRACKING_CODE_VARIABLE = '{$sOrder.trackingcode}';
-
-    /**
      * @var MollieGatewayInterface
      */
     private $gwMollie;
 
+    /**
+     * @var \Smarty
+     */
+    private $smarty;
+
 
     /**
+     * MollieShipping constructor.
      * @param MollieGatewayInterface $gwMollie
+     * @param \Smarty $smarty
      */
-    public function __construct(MollieGatewayInterface $gwMollie)
+    public function __construct(MollieGatewayInterface $gwMollie, \Smarty $smarty)
     {
         $this->gwMollie = $gwMollie;
+        $this->smarty = $smarty;
     }
 
     /**
@@ -41,16 +44,23 @@ class MollieShipping
         $hasDispatch = ($order->getDispatch() instanceof Dispatch) && ($order->getDispatch()->getId() > 0);
 
         $shippingCarrier = (string)($hasDispatch) ? trim($order->getDispatch()->getName()) : '-';
-        $trackingUrl = (string)($hasDispatch) ? trim($order->getDispatch()->getStatusLink()) : '';
         $trackingCode = (string)trim($order->getTrackingCode());
+        $trackingUrl = '';
 
         # replace the tracking code variable in our tracking URL
-        if (!empty($trackingUrl)) {
-            $trackingUrl = str_replace(self::TRACKING_CODE_VARIABLE, $trackingCode, $trackingUrl);
+        if (!empty($trackingCode)) {
+
+            # if we have a tracking code,
+            # then grab our smarty tracking url template
+            $smartyTrackingUrl = (string)($hasDispatch) ? trim($order->getDispatch()->getStatusLink()) : '';
+
+            # fill our smarty url template with
+            # real values, so we get a final URL
+            $trackingUrl = $this->fillTrackingUrl($smartyTrackingUrl, $trackingCode);
         }
 
-        # now validate if the tracking URL is a valid URL
-        # if not, just remove it
+
+        # now validate if the tracking URL is a valid URL if not, just remove it
         if (filter_var($trackingUrl, FILTER_VALIDATE_URL) === FALSE) {
             $trackingUrl = '';
         }
@@ -61,6 +71,63 @@ class MollieShipping
             $trackingCode,
             $trackingUrl
         );
+    }
+
+    /**
+     * @param $smartyTrackingUrl
+     * @param $trackingCode
+     * @return array|string|string[]
+     */
+    private function fillTrackingUrl($smartyTrackingUrl, $trackingCode)
+    {
+        # assign our defined shopware variables for tracking
+        # if one of these is used, then we replace it
+        # https://docs.shopware.com/en/shopware-5-en/tutorials-and-faq/tracking-numbers-and-tracking#providing-tracking-urls-in-the-frontend
+
+        $this->smarty->assign(
+            'sOrder',
+            ['trackingcode' => $trackingCode,]
+        );
+
+        $this->smarty->assign(
+            'offerPosition',
+            ['trackingcode' => $trackingCode,]
+        );
+
+        try {
+
+            $trackingUrl = $this->smarty->fetch('string:' . $smartyTrackingUrl);
+
+        } catch (\Exception $ex) {
+
+            $trackingUrl = '';
+        }
+
+        # also return any characters that might be left
+        # and are not allowed by Mollie
+        if ($this->stringContains('{', $trackingUrl)) {
+            $trackingUrl = '';
+        }
+
+        if ($this->stringContains('}', $trackingUrl)) {
+            $trackingUrl = '';
+        }
+
+        return $trackingUrl;
+    }
+
+    /**
+     * @param $needle
+     * @param $haystack
+     * @return bool
+     */
+    private function stringContains($needle, $haystack)
+    {
+        if (strpos($haystack, $needle) !== false) {
+            return true;
+        }
+
+        return false;
     }
 
 }

--- a/Components/Services/PaymentService.php
+++ b/Components/Services/PaymentService.php
@@ -123,6 +123,11 @@ class PaymentService
      */
     private $translations;
 
+    /**
+     * @var \Enlight_Template_Manager
+     */
+    private $smarty;
+
     private $orderLinesRepo;
 
 
@@ -147,6 +152,8 @@ class PaymentService
         $this->repoPaymentConfig = Shopware()->Models()->getRepository(Configuration::class);
 
         $this->translations = Shopware()->Container()->get('mollie_shopware.components.translation');
+
+        $this->smarty = Shopware()->Container()->get('template');
 
         $this->paymentFactory = new PaymentFactory();
     }
@@ -508,7 +515,7 @@ class PaymentService
             }
 
 
-            $mollieShipping = new MollieShipping($this->gwMollie);
+            $mollieShipping = new MollieShipping($this->gwMollie, $this->smarty);
 
             return $mollieShipping->shipOrder($shopwareOrder, $mollieOrder);
         }

--- a/Controllers/Backend/MollieOrders.php
+++ b/Controllers/Backend/MollieOrders.php
@@ -185,6 +185,9 @@ class Shopware_Controllers_Backend_MollieOrders extends Shopware_Controllers_Bac
             /** @var MollieGatewayFactory $gwMollie */
             $gwMollieFactory = $this->container->get('mollie_shopware.gateways.mollie.factory');
 
+            /** @var Enlight_Template_Manager $smarty */
+            $smarty = $this->container->get('template');
+
 
             /** @var \Shopware\Models\Order\Order $order */
             $order = $this->orderService->getOrderById(
@@ -235,7 +238,7 @@ class Shopware_Controllers_Backend_MollieOrders extends Shopware_Controllers_Bac
                 $this->returnError($errorMessage);
             }
 
-            $mollieShipping = new MollieShipping($gwMollie);
+            $mollieShipping = new MollieShipping($gwMollie, $smarty);
 
             $result = $mollieShipping->shipOrder($order, $mollieOrder);
 

--- a/Resources/services/commands.xml
+++ b/Resources/services/commands.xml
@@ -10,6 +10,7 @@
             <tag name="console.command" command="mollie:ship:klarna"/>
             <argument type="service" id="mollie_shopware.config"/>
             <argument type="service" id="models"/>
+            <argument type="service" id="template"/>
             <argument type="service" id="mollie_shopware.gateways.mollie"/>
             <argument type="service" id="mollie_shopware.components.logger"/>
         </service>
@@ -18,6 +19,7 @@
             <tag name="console.command" command="mollie:ship:orders"/>
             <argument type="service" id="mollie_shopware.config"/>
             <argument type="service" id="models"/>
+            <argument type="service" id="template"/>
             <argument type="service" id="mollie_shopware.gateways.mollie"/>
             <argument type="service" id="mollie_shopware.components.logger"/>
         </service>


### PR DESCRIPTION
had to change tracking URL building to smarty, because it involves smarty variables.
unknown smarty variables where accidentally kept in the url which leads to an invalid URL (....{$xyz}...)

thx to the smarty version, unknown variables will be removed automatically,
while still additional url checks persist in the code

also added an additional officially supported variable offerPosition.trackingcode