### PR TITLE
MOL-508: Fix different shipping address for orders

### DIFF
--- a/Controllers/Frontend/Mollie.php
+++ b/Controllers/Frontend/Mollie.php
@@ -141,6 +141,14 @@ class Shopware_Controllers_Frontend_Mollie extends AbstractPaymentController
 
             $currency = method_exists($this, 'getCurrencyShortName') ? $this->getCurrencyShortName() : 'EUR';
 
+            # we need to extract the IDs here, because we need to
+            # send the correct billing and shipping data to Mollie.
+            # there is no order entity existing at this step, so we
+            # need to get that data from here.
+            $billingAddressID = (int)$this->getUser()['billingaddress']['id'];
+            $shippingAddressID = (int)$this->getUser()['shippingaddress']['id'];
+
+
             # create a new checkout session
             # by preparing transactions, orders and more
             $session = $this->checkout->startCheckoutSession(
@@ -148,7 +156,9 @@ class Shopware_Controllers_Frontend_Mollie extends AbstractPaymentController
                 $this->getPaymentShortName(),
                 $signature,
                 $currency,
-                Shopware()->Shop()->getId()
+                Shopware()->Shop()->getId(),
+                $billingAddressID,
+                $shippingAddressID
             );
 
             # some payment methods do not require a redirect to mollie.

--- a/Facades/CheckoutSession/CheckoutSessionFacade.php
+++ b/Facades/CheckoutSession/CheckoutSessionFacade.php
@@ -21,6 +21,7 @@ use MollieShopware\Models\Transaction;
 use MollieShopware\Models\TransactionRepository;
 use MollieShopware\Services\TokenAnonymizer\TokenAnonymizer;
 use Psr\Log\LoggerInterface;
+use sBasket;
 use Shopware\Components\Model\ModelManager;
 use Shopware\Models\Order\Order;
 use Shopware_Controllers_Frontend_Payment;
@@ -79,7 +80,7 @@ class CheckoutSessionFacade
     private $restorableOrder;
 
     /**
-     * @var $sBasket
+     * @var sBasket
      */
     private $sBasket;
 
@@ -183,6 +184,8 @@ class CheckoutSessionFacade
      * @param $basketSignature
      * @param $currencyShortName
      * @param $shopId
+     * @param $billingAddressID
+     * @param $shippingAddressID
      * @return CheckoutSession
      * @throws \Doctrine\DBAL\Exception
      * @throws \Doctrine\ORM\ORMException
@@ -190,7 +193,7 @@ class CheckoutSessionFacade
      * @throws \MollieShopware\Exceptions\MolliePaymentConfigurationNotFound
      * @throws \Mollie\Api\Exceptions\ApiException
      */
-    public function startCheckoutSession($basketUserId, $paymentShortName, $basketSignature, $currencyShortName, $shopId)
+    public function startCheckoutSession($basketUserId, $paymentShortName, $basketSignature, $currencyShortName, $shopId, $billingAddressID, $shippingAddressID)
     {
         # immediately reset our previous order
         # just to make sure we don't have a previous one accidentally
@@ -232,7 +235,6 @@ class CheckoutSessionFacade
                 ]
             ]
         );
-
 
         # to avoid problems on lost sessions, we have to ensure
         # that we can restore a session.
@@ -279,7 +281,9 @@ class CheckoutSessionFacade
         $checkoutUrl = $this->paymentService->startMollieSession(
             $paymentShortName,
             $transaction,
-            $paymentToken
+            $paymentToken,
+            $billingAddressID,
+            $shippingAddressID
         );
 
         # some payment methods are approved and

--- a/Tests/PHPUnit/Services/Mollie/Payments/Requests/ApplePayTest.php
+++ b/Tests/PHPUnit/Services/Mollie/Payments/Requests/ApplePayTest.php
@@ -23,7 +23,12 @@ class ApplePayTest extends TestCase
     /**
      * @var PaymentAddress
      */
-    private $address;
+    private $addressInvoice;
+
+    /**
+     * @var PaymentAddress
+     */
+    private $addressShipping;
 
     /**
      * @var PaymentLineItem
@@ -37,7 +42,8 @@ class ApplePayTest extends TestCase
     {
         $this->payment = new ApplePay();
 
-        $this->address = $this->getAddressFixture();
+        $this->addressInvoice = $this->getAddressFixture1();
+        $this->addressShipping = $this->getAddressFixture2();
         $this->lineItem = $this->getLineItemFixture();
 
         $this->payment->setPayment(
@@ -45,8 +51,8 @@ class ApplePayTest extends TestCase
                 'UUID-123',
                 'Payment UUID-123',
                 '20004',
-                $this->address,
-                $this->address,
+                $this->addressInvoice,
+                $this->addressShipping,
                 49.98,
                 [$this->lineItem],
                 'USD',
@@ -99,8 +105,8 @@ class ApplePayTest extends TestCase
             'payment' => [
                 'webhookUrl' => 'https://local/notify',
             ],
-            'billingAddress' => $this->getExpectedAddressStructure($this->address),
-            'shippingAddress' => $this->getExpectedAddressStructure($this->address),
+            'billingAddress' => $this->getExpectedAddressStructure($this->addressInvoice),
+            'shippingAddress' => $this->getExpectedAddressStructure($this->addressShipping),
             'lines' => [
                 $this->getExpectedLineItemStructure($this->lineItem),
             ],

--- a/Tests/PHPUnit/Services/Mollie/Payments/Requests/BancontactTest.php
+++ b/Tests/PHPUnit/Services/Mollie/Payments/Requests/BancontactTest.php
@@ -23,7 +23,13 @@ class BancontactTest extends TestCase
     /**
      * @var PaymentAddress
      */
-    private $address;
+    private $addressInvoice;
+
+    /**
+     * @var PaymentAddress
+     */
+    private $addressShipping;
+
 
     /**
      * @var PaymentLineItem
@@ -37,7 +43,8 @@ class BancontactTest extends TestCase
     {
         $this->payment = new Bancontact();
 
-        $this->address = $this->getAddressFixture();
+        $this->addressInvoice = $this->getAddressFixture1();
+        $this->addressShipping = $this->getAddressFixture2();
         $this->lineItem = $this->getLineItemFixture();
 
         $this->payment->setPayment(
@@ -45,8 +52,8 @@ class BancontactTest extends TestCase
                 'UUID-123',
                 'Order UUID-123',
                 '20004',
-                $this->address,
-                $this->address,
+                $this->addressInvoice,
+                $this->addressShipping,
                 49.98,
                 [$this->lineItem],
                 'USD',
@@ -100,8 +107,8 @@ class BancontactTest extends TestCase
             'payment' => [
                 'webhookUrl' => 'https://local/notify',
             ],
-            'billingAddress' => $this->getExpectedAddressStructure($this->address),
-            'shippingAddress' => $this->getExpectedAddressStructure($this->address),
+            'billingAddress' => $this->getExpectedAddressStructure($this->addressInvoice),
+            'shippingAddress' => $this->getExpectedAddressStructure($this->addressShipping),
             'lines' => [
                 $this->getExpectedLineItemStructure($this->lineItem),
             ],

--- a/Tests/PHPUnit/Services/Mollie/Payments/Requests/BankTransferTest.php
+++ b/Tests/PHPUnit/Services/Mollie/Payments/Requests/BankTransferTest.php
@@ -23,7 +23,13 @@ class BankTransferTest extends TestCase
     /**
      * @var PaymentAddress
      */
-    private $address;
+    private $addressInvoice;
+
+    /**
+     * @var PaymentAddress
+     */
+    private $addressShipping;
+
 
     /**
      * @var PaymentLineItem
@@ -37,7 +43,8 @@ class BankTransferTest extends TestCase
     {
         $this->payment = new BankTransfer();
 
-        $this->address = $this->getAddressFixture();
+        $this->addressInvoice = $this->getAddressFixture1();
+        $this->addressShipping = $this->getAddressFixture2();
         $this->lineItem = $this->getLineItemFixture();
 
         $this->payment->setPayment(
@@ -45,8 +52,8 @@ class BankTransferTest extends TestCase
                 'UUID-123',
                 'Payment UUID-123',
                 '20004',
-                $this->address,
-                $this->address,
+                $this->addressInvoice,
+                $this->addressShipping,
                 49.98,
                 [$this->lineItem],
                 'USD',
@@ -100,8 +107,8 @@ class BankTransferTest extends TestCase
             'payment' => [
                 'webhookUrl' => 'https://local/notify',
             ],
-            'billingAddress' => $this->getExpectedAddressStructure($this->address),
-            'shippingAddress' => $this->getExpectedAddressStructure($this->address),
+            'billingAddress' => $this->getExpectedAddressStructure($this->addressInvoice),
+            'shippingAddress' => $this->getExpectedAddressStructure($this->addressShipping),
             'lines' => [
                 $this->getExpectedLineItemStructure($this->lineItem),
             ],

--- a/Tests/PHPUnit/Services/Mollie/Payments/Requests/BelfiusTest.php
+++ b/Tests/PHPUnit/Services/Mollie/Payments/Requests/BelfiusTest.php
@@ -23,7 +23,13 @@ class BelfiusTest extends TestCase
     /**
      * @var PaymentAddress
      */
-    private $address;
+    private $addressInvoice;
+
+    /**
+     * @var PaymentAddress
+     */
+    private $addressShipping;
+
 
     /**
      * @var PaymentLineItem
@@ -37,7 +43,8 @@ class BelfiusTest extends TestCase
     {
         $this->payment = new Belfius();
 
-        $this->address = $this->getAddressFixture();
+        $this->addressInvoice = $this->getAddressFixture1();
+        $this->addressShipping = $this->getAddressFixture2();
         $this->lineItem = $this->getLineItemFixture();
 
         $this->payment->setPayment(
@@ -45,8 +52,8 @@ class BelfiusTest extends TestCase
                 'UUID-123',
                 'Payment UUID-123',
                 '20004',
-                $this->address,
-                $this->address,
+                $this->addressInvoice,
+                $this->addressShipping,
                 49.98,
                 [$this->lineItem],
                 'USD',
@@ -99,8 +106,8 @@ class BelfiusTest extends TestCase
             'payment' => [
                 'webhookUrl' => 'https://local/notify',
             ],
-            'billingAddress' => $this->getExpectedAddressStructure($this->address),
-            'shippingAddress' => $this->getExpectedAddressStructure($this->address),
+            'billingAddress' => $this->getExpectedAddressStructure($this->addressInvoice),
+            'shippingAddress' => $this->getExpectedAddressStructure($this->addressShipping),
             'lines' => [
                 $this->getExpectedLineItemStructure($this->lineItem),
             ],

--- a/Tests/PHPUnit/Services/Mollie/Payments/Requests/CreditCardTest.php
+++ b/Tests/PHPUnit/Services/Mollie/Payments/Requests/CreditCardTest.php
@@ -23,7 +23,13 @@ class CreditCardTest extends TestCase
     /**
      * @var PaymentAddress
      */
-    private $address;
+    private $addressInvoice;
+
+    /**
+     * @var PaymentAddress
+     */
+    private $addressShipping;
+
 
     /**
      * @var PaymentLineItem
@@ -37,7 +43,8 @@ class CreditCardTest extends TestCase
     {
         $this->payment = new CreditCard();
 
-        $this->address = $this->getAddressFixture();
+        $this->addressInvoice = $this->getAddressFixture1();
+        $this->addressShipping = $this->getAddressFixture2();
         $this->lineItem = $this->getLineItemFixture();
 
         $this->payment->setPayment(
@@ -45,8 +52,8 @@ class CreditCardTest extends TestCase
                 'UUID-123',
                 'Payment UUID-123',
                 '20004',
-                $this->address,
-                $this->address,
+                $this->addressInvoice,
+                $this->addressShipping,
                 49.98,
                 [$this->lineItem],
                 'USD',
@@ -99,8 +106,8 @@ class CreditCardTest extends TestCase
             'payment' => [
                 'webhookUrl' => 'https://local/notify',
             ],
-            'billingAddress' => $this->getExpectedAddressStructure($this->address),
-            'shippingAddress' => $this->getExpectedAddressStructure($this->address),
+            'billingAddress' => $this->getExpectedAddressStructure($this->addressInvoice),
+            'shippingAddress' => $this->getExpectedAddressStructure($this->addressShipping),
             'lines' => [
                 $this->getExpectedLineItemStructure($this->lineItem),
             ],

--- a/Tests/PHPUnit/Services/Mollie/Payments/Requests/EPSTest.php
+++ b/Tests/PHPUnit/Services/Mollie/Payments/Requests/EPSTest.php
@@ -23,7 +23,13 @@ class EPSTest extends TestCase
     /**
      * @var PaymentAddress
      */
-    private $address;
+    private $addressInvoice;
+
+    /**
+     * @var PaymentAddress
+     */
+    private $addressShipping;
+
 
     /**
      * @var PaymentLineItem
@@ -37,7 +43,8 @@ class EPSTest extends TestCase
     {
         $this->payment = new EPS();
 
-        $this->address = $this->getAddressFixture();
+        $this->addressInvoice = $this->getAddressFixture1();
+        $this->addressShipping = $this->getAddressFixture2();
         $this->lineItem = $this->getLineItemFixture();
 
         $this->payment->setPayment(
@@ -45,8 +52,8 @@ class EPSTest extends TestCase
                 'UUID-123',
                 'Order UUID-123',
                 '20004',
-                $this->address,
-                $this->address,
+                $this->addressInvoice,
+                $this->addressShipping,
                 49.98,
                 [$this->lineItem],
                 'USD',
@@ -99,8 +106,8 @@ class EPSTest extends TestCase
             'payment' => [
                 'webhookUrl' => 'https://local/notify',
             ],
-            'billingAddress' => $this->getExpectedAddressStructure($this->address),
-            'shippingAddress' => $this->getExpectedAddressStructure($this->address),
+            'billingAddress' => $this->getExpectedAddressStructure($this->addressInvoice),
+            'shippingAddress' => $this->getExpectedAddressStructure($this->addressShipping),
             'lines' => [
                 $this->getExpectedLineItemStructure($this->lineItem),
             ],

--- a/Tests/PHPUnit/Services/Mollie/Payments/Requests/GiropayTest.php
+++ b/Tests/PHPUnit/Services/Mollie/Payments/Requests/GiropayTest.php
@@ -23,7 +23,13 @@ class GiropayTest extends TestCase
     /**
      * @var PaymentAddress
      */
-    private $address;
+    private $addressInvoice;
+
+    /**
+     * @var PaymentAddress
+     */
+    private $addressShipping;
+
 
     /**
      * @var PaymentLineItem
@@ -37,7 +43,8 @@ class GiropayTest extends TestCase
     {
         $this->payment = new Giropay();
 
-        $this->address = $this->getAddressFixture();
+        $this->addressInvoice = $this->getAddressFixture1();
+        $this->addressShipping = $this->getAddressFixture2();
         $this->lineItem = $this->getLineItemFixture();
 
         $this->payment->setPayment(
@@ -45,8 +52,8 @@ class GiropayTest extends TestCase
                 'UUID-123',
                 'Order UUID-123',
                 '20004',
-                $this->address,
-                $this->address,
+                $this->addressInvoice,
+                $this->addressShipping,
                 49.98,
                 [$this->lineItem],
                 'USD',
@@ -99,8 +106,8 @@ class GiropayTest extends TestCase
             'payment' => [
                 'webhookUrl' => 'https://local/notify',
             ],
-            'billingAddress' => $this->getExpectedAddressStructure($this->address),
-            'shippingAddress' => $this->getExpectedAddressStructure($this->address),
+            'billingAddress' => $this->getExpectedAddressStructure($this->addressInvoice),
+            'shippingAddress' => $this->getExpectedAddressStructure($this->addressShipping),
             'lines' => [
                 $this->getExpectedLineItemStructure($this->lineItem),
             ],

--- a/Tests/PHPUnit/Services/Mollie/Payments/Requests/IDealTest.php
+++ b/Tests/PHPUnit/Services/Mollie/Payments/Requests/IDealTest.php
@@ -23,7 +23,13 @@ class IDealTest extends TestCase
     /**
      * @var PaymentAddress
      */
-    private $address;
+    private $addressInvoice;
+
+    /**
+     * @var PaymentAddress
+     */
+    private $addressShipping;
+
 
     /**
      * @var PaymentLineItem
@@ -37,7 +43,8 @@ class IDealTest extends TestCase
     {
         $this->payment = new iDeal();
 
-        $this->address = $this->getAddressFixture();
+        $this->addressInvoice = $this->getAddressFixture1();
+        $this->addressShipping = $this->getAddressFixture2();
         $this->lineItem = $this->getLineItemFixture();
 
         $this->payment->setPayment(
@@ -45,8 +52,8 @@ class IDealTest extends TestCase
                 'UUID-123',
                 'Payment UUID-123',
                 '20004',
-                $this->address,
-                $this->address,
+                $this->addressInvoice,
+                $this->addressShipping,
                 49.98,
                 [$this->lineItem],
                 'USD',
@@ -99,8 +106,8 @@ class IDealTest extends TestCase
             'payment' => [
                 'webhookUrl' => 'https://local/notify',
             ],
-            'billingAddress' => $this->getExpectedAddressStructure($this->address),
-            'shippingAddress' => $this->getExpectedAddressStructure($this->address),
+            'billingAddress' => $this->getExpectedAddressStructure($this->addressInvoice),
+            'shippingAddress' => $this->getExpectedAddressStructure($this->addressShipping),
             'lines' => [
                 $this->getExpectedLineItemStructure($this->lineItem),
             ],

--- a/Tests/PHPUnit/Services/Mollie/Payments/Requests/KBCTest.php
+++ b/Tests/PHPUnit/Services/Mollie/Payments/Requests/KBCTest.php
@@ -23,7 +23,13 @@ class KBCTest extends TestCase
     /**
      * @var PaymentAddress
      */
-    private $address;
+    private $addressInvoice;
+
+    /**
+     * @var PaymentAddress
+     */
+    private $addressShipping;
+
 
     /**
      * @var PaymentLineItem
@@ -37,7 +43,8 @@ class KBCTest extends TestCase
     {
         $this->payment = new KBC();
 
-        $this->address = $this->getAddressFixture();
+        $this->addressInvoice = $this->getAddressFixture1();
+        $this->addressShipping = $this->getAddressFixture2();
         $this->lineItem = $this->getLineItemFixture();
 
         $this->payment->setPayment(
@@ -45,8 +52,8 @@ class KBCTest extends TestCase
                 'UUID-123',
                 'Payment UUID-123',
                 '20004',
-                $this->address,
-                $this->address,
+                $this->addressInvoice,
+                $this->addressShipping,
                 49.98,
                 [$this->lineItem],
                 'USD',
@@ -99,8 +106,8 @@ class KBCTest extends TestCase
             'payment' => [
                 'webhookUrl' => 'https://local/notify',
             ],
-            'billingAddress' => $this->getExpectedAddressStructure($this->address),
-            'shippingAddress' => $this->getExpectedAddressStructure($this->address),
+            'billingAddress' => $this->getExpectedAddressStructure($this->addressInvoice),
+            'shippingAddress' => $this->getExpectedAddressStructure($this->addressShipping),
             'lines' => [
                 $this->getExpectedLineItemStructure($this->lineItem),
             ],

--- a/Tests/PHPUnit/Services/Mollie/Payments/Requests/PayLaterTest.php
+++ b/Tests/PHPUnit/Services/Mollie/Payments/Requests/PayLaterTest.php
@@ -24,7 +24,12 @@ class PayLaterTest extends TestCase
     /**
      * @var PaymentAddress
      */
-    private $address;
+    private $addressInvoice;
+
+    /**
+     * @var PaymentAddress
+     */
+    private $addressShipping;
 
     /**
      * @var PaymentLineItem
@@ -38,7 +43,8 @@ class PayLaterTest extends TestCase
     {
         $this->payment = new PayLater();
 
-        $this->address = $this->getAddressFixture();
+        $this->addressInvoice = $this->getAddressFixture1();
+        $this->addressShipping = $this->getAddressFixture2();
         $this->lineItem = $this->getLineItemFixture();
 
         $this->payment->setPayment(
@@ -46,8 +52,8 @@ class PayLaterTest extends TestCase
                 'UUID-123',
                 'Order UUID-123',
                 '20004',
-                $this->address,
-                $this->address,
+                $this->addressInvoice,
+                $this->addressShipping,
                 49.98,
                 [$this->lineItem],
                 'USD',
@@ -90,8 +96,8 @@ class PayLaterTest extends TestCase
             'payment' => [
                 'webhookUrl' => 'https://local/notify',
             ],
-            'billingAddress' => $this->getExpectedAddressStructure($this->address),
-            'shippingAddress' => $this->getExpectedAddressStructure($this->address),
+            'billingAddress' => $this->getExpectedAddressStructure($this->addressInvoice),
+            'shippingAddress' => $this->getExpectedAddressStructure($this->addressShipping),
             'lines' => [
                 $this->getExpectedLineItemStructure($this->lineItem),
             ],

--- a/Tests/PHPUnit/Services/Mollie/Payments/Requests/PaypalTest.php
+++ b/Tests/PHPUnit/Services/Mollie/Payments/Requests/PaypalTest.php
@@ -24,7 +24,13 @@ class PaypalTest extends TestCase
     /**
      * @var PaymentAddress
      */
-    private $address;
+    private $addressInvoice;
+
+    /**
+     * @var PaymentAddress
+     */
+    private $addressShipping;
+
 
     /**
      * @var PaymentLineItem
@@ -39,7 +45,8 @@ class PaypalTest extends TestCase
     {
         $this->payment = new PayPal();
 
-        $this->address = $this->getAddressFixture();
+        $this->addressInvoice = $this->getAddressFixture1();
+        $this->addressShipping = $this->getAddressFixture2();
         $this->lineItem = $this->getLineItemFixture();
 
         $this->payment->setPayment(
@@ -47,8 +54,8 @@ class PaypalTest extends TestCase
                 'UUID-123',
                 'Payment UUID-123',
                 '20004',
-                $this->address,
-                $this->address,
+                $this->addressInvoice,
+                $this->addressShipping,
                 49.98,
                 [$this->lineItem],
                 'USD',
@@ -101,8 +108,8 @@ class PaypalTest extends TestCase
             'payment' => [
                 'webhookUrl' => 'https://local/notify',
             ],
-            'billingAddress' => $this->getExpectedAddressStructure($this->address),
-            'shippingAddress' => $this->getExpectedAddressStructure($this->address),
+            'billingAddress' => $this->getExpectedAddressStructure($this->addressInvoice),
+            'shippingAddress' => $this->getExpectedAddressStructure($this->addressShipping),
             'lines' => [
                 $this->getExpectedLineItemStructure($this->lineItem),
             ],

--- a/Tests/PHPUnit/Services/Mollie/Payments/Requests/Przelewy24Test.php
+++ b/Tests/PHPUnit/Services/Mollie/Payments/Requests/Przelewy24Test.php
@@ -23,7 +23,13 @@ class Przelewy24Test extends TestCase
     /**
      * @var PaymentAddress
      */
-    private $address;
+    private $addressInvoice;
+
+    /**
+     * @var PaymentAddress
+     */
+    private $addressShipping;
+
 
     /**
      * @var PaymentLineItem
@@ -37,7 +43,8 @@ class Przelewy24Test extends TestCase
     {
         $this->payment = new Przelewy24();
 
-        $this->address = $this->getAddressFixture();
+        $this->addressInvoice = $this->getAddressFixture1();
+        $this->addressShipping = $this->getAddressFixture2();
         $this->lineItem = $this->getLineItemFixture();
 
         $this->payment->setPayment(
@@ -45,8 +52,8 @@ class Przelewy24Test extends TestCase
                 'UUID-123',
                 'Order UUID-123',
                 '20004',
-                $this->address,
-                $this->address,
+                $this->addressInvoice,
+                $this->addressShipping,
                 49.98,
                 [$this->lineItem],
                 'USD',
@@ -100,8 +107,8 @@ class Przelewy24Test extends TestCase
             'payment' => [
                 'webhookUrl' => 'https://local/notify',
             ],
-            'billingAddress' => $this->getExpectedAddressStructure($this->address),
-            'shippingAddress' => $this->getExpectedAddressStructure($this->address),
+            'billingAddress' => $this->getExpectedAddressStructure($this->addressInvoice),
+            'shippingAddress' => $this->getExpectedAddressStructure($this->addressShipping),
             'lines' => [
                 $this->getExpectedLineItemStructure($this->lineItem),
             ],

--- a/Tests/PHPUnit/Services/Mollie/Payments/Requests/SepaDirectDebitTest.php
+++ b/Tests/PHPUnit/Services/Mollie/Payments/Requests/SepaDirectDebitTest.php
@@ -23,7 +23,13 @@ class SepaDirectDebitTest extends TestCase
     /**
      * @var PaymentAddress
      */
-    private $address;
+    private $addressInvoice;
+
+    /**
+     * @var PaymentAddress
+     */
+    private $addressShipping;
+
 
     /**
      * @var PaymentLineItem
@@ -37,7 +43,8 @@ class SepaDirectDebitTest extends TestCase
     {
         $this->payment = new SepaDirectDebit();
 
-        $this->address = $this->getAddressFixture();
+        $this->addressInvoice = $this->getAddressFixture1();
+        $this->addressShipping = $this->getAddressFixture2();
         $this->lineItem = $this->getLineItemFixture();
 
         $this->payment->setPayment(
@@ -45,8 +52,8 @@ class SepaDirectDebitTest extends TestCase
                 'UUID-123',
                 'Payment UUID-123',
                 '20004',
-                $this->address,
-                $this->address,
+                $this->addressInvoice,
+                $this->addressShipping,
                 49.98,
                 [$this->lineItem],
                 'USD',
@@ -100,8 +107,8 @@ class SepaDirectDebitTest extends TestCase
             'payment' => [
                 'webhookUrl' => 'https://local/notify',
             ],
-            'billingAddress' => $this->getExpectedAddressStructure($this->address),
-            'shippingAddress' => $this->getExpectedAddressStructure($this->address),
+            'billingAddress' => $this->getExpectedAddressStructure($this->addressInvoice),
+            'shippingAddress' => $this->getExpectedAddressStructure($this->addressShipping),
             'lines' => [
                 $this->getExpectedLineItemStructure($this->lineItem),
             ],

--- a/Tests/PHPUnit/Services/Mollie/Payments/Requests/SliceItTest.php
+++ b/Tests/PHPUnit/Services/Mollie/Payments/Requests/SliceItTest.php
@@ -24,7 +24,13 @@ class SliceItTest extends TestCase
     /**
      * @var PaymentAddress
      */
-    private $address;
+    private $addressInvoice;
+
+    /**
+     * @var PaymentAddress
+     */
+    private $addressShipping;
+
 
     /**
      * @var PaymentLineItem
@@ -38,7 +44,8 @@ class SliceItTest extends TestCase
     {
         $this->payment = new SliceIt();
 
-        $this->address = $this->getAddressFixture();
+        $this->addressInvoice = $this->getAddressFixture1();
+        $this->addressShipping = $this->getAddressFixture2();
         $this->lineItem = $this->getLineItemFixture();
 
         $this->payment->setPayment(
@@ -46,8 +53,8 @@ class SliceItTest extends TestCase
                 'UUID-123',
                 'Payment UUID-123',
                 '20004',
-                $this->address,
-                $this->address,
+                $this->addressInvoice,
+                $this->addressShipping,
                 49.98,
                 [$this->lineItem],
                 'USD',
@@ -90,8 +97,8 @@ class SliceItTest extends TestCase
             'payment' => [
                 'webhookUrl' => 'https://local/notify',
             ],
-            'billingAddress' => $this->getExpectedAddressStructure($this->address),
-            'shippingAddress' => $this->getExpectedAddressStructure($this->address),
+            'billingAddress' => $this->getExpectedAddressStructure($this->addressInvoice),
+            'shippingAddress' => $this->getExpectedAddressStructure($this->addressShipping),
             'lines' => [
                 $this->getExpectedLineItemStructure($this->lineItem),
             ],

--- a/Tests/PHPUnit/Services/Mollie/Payments/Requests/SofortTest.php
+++ b/Tests/PHPUnit/Services/Mollie/Payments/Requests/SofortTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 class SofortTest extends TestCase
 {
     use PaymentTestTrait;
-    
+
     /**
      * @var Sofort
      */
@@ -22,7 +22,13 @@ class SofortTest extends TestCase
     /**
      * @var PaymentAddress
      */
-    private $address;
+    private $addressInvoice;
+
+    /**
+     * @var PaymentAddress
+     */
+    private $addressShipping;
+
 
     /**
      * @var PaymentLineItem
@@ -36,7 +42,8 @@ class SofortTest extends TestCase
     {
         $this->payment = new Sofort();
 
-        $this->address = $this->getAddressFixture();
+        $this->addressInvoice = $this->getAddressFixture1();
+        $this->addressShipping = $this->getAddressFixture2();
         $this->lineItem = $this->getLineItemFixture();
 
         $this->payment->setPayment(
@@ -44,8 +51,8 @@ class SofortTest extends TestCase
                 'UUID-123',
                 'Payment UUID-123',
                 '20004',
-                $this->address,
-                $this->address,
+                $this->addressInvoice,
+                $this->addressShipping,
                 49.98,
                 [$this->lineItem],
                 'USD',
@@ -99,8 +106,8 @@ class SofortTest extends TestCase
             'payment' => [
                 'webhookUrl' => 'https://local/notify',
             ],
-            'billingAddress' => $this->getExpectedAddressStructure($this->address),
-            'shippingAddress' => $this->getExpectedAddressStructure($this->address),
+            'billingAddress' => $this->getExpectedAddressStructure($this->addressInvoice),
+            'shippingAddress' => $this->getExpectedAddressStructure($this->addressShipping),
             'lines' => [
                 $this->getExpectedLineItemStructure($this->lineItem),
             ],

--- a/Tests/PHPUnit/Utils/Fixtures/PaymentAddressFixture.php
+++ b/Tests/PHPUnit/Utils/Fixtures/PaymentAddressFixture.php
@@ -9,6 +9,22 @@ class PaymentAddressFixture
 {
 
     /**
+     * @var string
+     */
+    private $city;
+
+
+    /**
+     * PaymentAddressFixture constructor.
+     * @param string $city
+     */
+    public function __construct($city)
+    {
+        $this->city = $city;
+    }
+
+
+    /**
      * @return PaymentAddress
      */
     public function buildAddress()
@@ -21,11 +37,9 @@ class PaymentAddressFixture
             'Mollie Street',
             'Addon',
             '1000',
-            'Munich',
+            $this->city,
             'DE'
         );
     }
-
-
 
 }

--- a/Tests/PHPUnit/Utils/Traits/PaymentTestTrait.php
+++ b/Tests/PHPUnit/Utils/Traits/PaymentTestTrait.php
@@ -15,9 +15,17 @@ trait PaymentTestTrait
     /***
      * @return PaymentAddress
      */
-    protected function getAddressFixture()
+    protected function getAddressFixture1()
     {
-        return (new PaymentAddressFixture())->buildAddress();
+        return (new PaymentAddressFixture('Munich'))->buildAddress();
+    }
+
+    /***
+     * @return PaymentAddress
+     */
+    protected function getAddressFixture2()
+    {
+        return (new PaymentAddressFixture('Amsterdam'))->buildAddress();
     }
 
     /**


### PR DESCRIPTION
the code did always use the default shipping address the customer
and not the shipping address that has been used in the order

the address IDs are not available in the transaction (only customer id)
so i just use the default shopware session data that has both IDs.

the payment builder will then fetch the addresses with those IDs instead of the customers default addresses