### PR TITLE
MOL-570: Only update order number when finishing checkout

### DIFF
--- a/Facades/FinishCheckout/FinishCheckoutFacade.php
+++ b/Facades/FinishCheckout/FinishCheckoutFacade.php
@@ -249,8 +249,7 @@ class FinishCheckoutFacade
 
             # if we have a separate order entry in Mollie
             # make sure we update its number with the one from Shopware
-            $mollieOrder->orderNumber = (string)$orderNumber;
-            $mollieOrder->update();
+            $this->gwMollie->updateOrderNumber($mollieOrder->id, (string)$orderNumber);
         }
 
         # -------------------------------------------------------------------------------------------------------------

--- a/Gateways/Mollie/MollieGateway.php
+++ b/Gateways/Mollie/MollieGateway.php
@@ -140,6 +140,22 @@ class MollieGateway implements MollieGatewayInterface
     }
 
     /**
+     * @param $mollieId
+     * @param $orderNumber
+     * @return void
+     * @throws \Mollie\Api\Exceptions\ApiException
+     */
+    public function updateOrderNumber($mollieId, $orderNumber)
+    {
+        $this->apiClient->orders->update(
+            $mollieId,
+            [
+                'orderNumber' => $orderNumber,
+            ]
+        );
+    }
+
+    /**
      * @param Order $mollieOrder
      * @param string $carrier
      * @param string $trackingNumber

--- a/Gateways/MollieGatewayInterface.php
+++ b/Gateways/MollieGatewayInterface.php
@@ -45,6 +45,13 @@ interface MollieGatewayInterface
     public function getIdealIssuers();
 
     /**
+     * @param $mollieId
+     * @param $orderNumber
+     * @return mixed
+     */
+    public function updateOrderNumber($mollieId, $orderNumber);
+
+    /**
      * @param Order $mollieOrder
      * @param string $carrier
      * @param string $trackingNumber

--- a/Tests/PHPUnit/Utils/Fakes/Gateway/FakeMollieGateway.php
+++ b/Tests/PHPUnit/Utils/Fakes/Gateway/FakeMollieGateway.php
@@ -142,6 +142,15 @@ class FakeMollieGateway implements MollieGatewayInterface
     }
 
     /**
+     * @param $mollieId
+     * @param $orderNumber
+     * @return mixed|void
+     */
+    public function updateOrderNumber($mollieId, $orderNumber)
+    {
+    }
+
+    /**
      * @param Order $mollieOrder
      * @param string $carrier
      * @param string $trackingNumber


### PR DESCRIPTION
(MOL-570 API Update PR required*)

sometimes klarna says that the address cannot be updated, which is not even done in the plugin.
only the order number is updated

but the old api framework also sent the address data which might lead to this issues (only in live mode of course)

so we've updated the api framework and used the new functionality to really only update the order number