### PR TITLE
MOL-608: Update payment descriptions after Shopware order is created

### DIFF
--- a/Gateways/Mollie/MollieGateway.php
+++ b/Gateways/Mollie/MollieGateway.php
@@ -156,6 +156,22 @@ class MollieGateway implements MollieGatewayInterface
     }
 
     /**
+     * @param $paymentId
+     * @param $description
+     * @return void
+     * @throws \Mollie\Api\Exceptions\ApiException
+     */
+    public function updatePaymentDescription($paymentId, $description)
+    {
+        $this->apiClient->payments->update(
+            $paymentId,
+            [
+                'description' => $description,
+            ]
+        );
+    }
+
+    /**
      * @param Order $mollieOrder
      * @param string $carrier
      * @param string $trackingNumber

--- a/Gateways/MollieGatewayInterface.php
+++ b/Gateways/MollieGatewayInterface.php
@@ -52,6 +52,14 @@ interface MollieGatewayInterface
     public function updateOrderNumber($mollieId, $orderNumber);
 
     /**
+     * @param $paymentId
+     * @param $description
+     * @return void
+     * @throws \Mollie\Api\Exceptions\ApiException
+     */
+    public function updatePaymentDescription($paymentId, $description);
+
+    /**
      * @param Order $mollieOrder
      * @param string $carrier
      * @param string $trackingNumber

--- a/Tests/PHPUnit/Utils/Fakes/Gateway/FakeMollieGateway.php
+++ b/Tests/PHPUnit/Utils/Fakes/Gateway/FakeMollieGateway.php
@@ -151,6 +151,14 @@ class FakeMollieGateway implements MollieGatewayInterface
     }
 
     /**
+     * @param $paymentId
+     * @param $description
+     */
+    public function updatePaymentDescription($paymentId, $description)
+    {
+    }
+
+    /**
      * @param Order $mollieOrder
      * @param string $carrier
      * @param string $trackingNumber


### PR DESCRIPTION
this feature already exists for orders in mollie

now its also possible for transactions either as standalone payment or the connected payment of the order
...both should be updated