### PR TITLE
MOL-534: Avoid additional entities from being saved with a transaction

### DIFF
--- a/Facades/CheckoutSession/CheckoutSessionFacade.php
+++ b/Facades/CheckoutSession/CheckoutSessionFacade.php
@@ -209,7 +209,7 @@ class CheckoutSessionFacade
         # it contains all necessary things for upcoming workflows.
         $transaction = $this->buildTransaction($basketSignature, $currencyShortName);
         $this->modelManager->persist($transaction);
-        $this->modelManager->flush();
+        $this->modelManager->flush($transaction);
 
 
         $this->logger->info(


### PR DESCRIPTION
there was a side effect in a merchant shop.
somehow that save process made duplicate entities in other tables (reason for adding those other entities to the entity manager state is unclear and not within mollie)

this code avoids it by adding a better save procedure only for the transaction