### PR TITLE
NTR: Correct ApplePay merchantCapabilities

### DIFF
--- a/Resources/views/frontend/_public/src/js/applepay-direct.js
+++ b/Resources/views/frontend/_public/src/js/applepay-direct.js
@@ -245,7 +245,7 @@ function initApplePay() {
                 'visa',
                 'vPay',
             ],
-            merchantCapabilities: ['supports3DS', 'supportsEMV', 'supportsCredit', 'supportsDebit'],
+            merchantCapabilities: ['supports3DS'],
             total: {
                 label: label,
                 amount: 0,


### PR DESCRIPTION
See https://github.com/mollie/api-documentation/pull/816

When we signal `supportsEMV` to the client, we might receive a cryptogram that cannot be processed by Mollie under certain circumstances.

Additionally, `supportsCredit` and `supportsDebit` are superfluous together, as this [Apple Doc](https://developer.apple.com/documentation/apple_pay_on_the_web/applepaymerchantcapability) states them as optional and we support both.