### PR TITLE
MOL-649: set cleared date on paid webhooks

### DIFF
--- a/Controllers/Frontend/Mollie.php
+++ b/Controllers/Frontend/Mollie.php
@@ -677,7 +677,8 @@ class Shopware_Controllers_Frontend_Mollie extends AbstractPaymentController
                 $this->orderCancellation,
                 $sessionManager,
                 $paymentStatusResolver,
-                $paymentConfigResolver
+                $paymentConfigResolver,
+                $entityManager
             );
 
             $this->restoreSessionFacade = new RestoreSessionFacade(


### PR DESCRIPTION
one a "paid" webhooks is received, we set the cleared date (paid on) while its still empty

then this shopware default field is also working with mollie