### PR TITLE
MOL-688: Apple Pay Direct support for required phone numbers

### DIFF
--- a/Components/Account/Exception/RegistrationMissingFieldException.php
+++ b/Components/Account/Exception/RegistrationMissingFieldException.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace MollieShopware\Components\Account\Exception;
+
+
+class RegistrationMissingFieldException extends \Exception
+{
+
+    /**
+     * @var string
+     */
+    private $field;
+
+    /**
+     * @param string $field
+     */
+    public function __construct($field)
+    {
+        parent::__construct('Missing Field: ' . $field);
+
+        $this->field = $field;
+    }
+
+    /**
+     * @return string
+     */
+    public function getField()
+    {
+        return $this->field;
+    }
+
+}

--- a/Components/ApplePayDirect/Models/Button/ApplePayButton.php
+++ b/Components/ApplePayDirect/Models/Button/ApplePayButton.php
@@ -35,17 +35,24 @@ class ApplePayButton
      */
     private $restrictionIds;
 
+    /**
+     * @var bool
+     */
+    private $requirePhoneNumber;
+
 
     /**
      * @param bool $active
      * @param string $country
      * @param string $currency
+     * @param bool $requirePhoneNumber
      */
-    public function __construct($active, $country, $currency)
+    public function __construct($active, $country, $currency, $requirePhoneNumber)
     {
         $this->active = $active;
         $this->country = $country;
         $this->currency = $currency;
+        $this->requirePhoneNumber = $requirePhoneNumber;
 
         $this->displayOption = [];
         $this->restrictionIds = [];
@@ -93,6 +100,9 @@ class ApplePayButton
             'country' => $this->country,
             'currency' => $this->currency,
             'itemMode' => $this->isItemMode(),
+            'requirements' => [
+                'phone' => $this->requirePhoneNumber,
+            ],
             'displayOptions' => [],
         ];
 

--- a/Components/Translation/FrontendTranslation.php
+++ b/Components/Translation/FrontendTranslation.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace MollieShopware\Components\Translation;
+
+
+use Doctrine\DBAL\Connection;
+
+
+class FrontendTranslation
+{
+
+    const REGISTRATION_MISSING_FIELD = "GuestAccountRegistrationMissingField";
+
+
+    /**
+     * @var \Enlight_Components_Snippet_Namespace
+     */
+    private $snippetsFrontend;
+
+    /**
+     * @param \Shopware_Components_Snippet_Manager $snippets
+     */
+    public function __construct(\Shopware_Components_Snippet_Manager $snippets)
+    {
+        $this->snippetsFrontend = $snippets->getNamespace('frontend/mollie/plugins');
+    }
+
+    /**
+     * @param string $key
+     */
+    public function get($key)
+    {
+        return (string)$this->snippetsFrontend->get($key, $key);
+    }
+
+    /**
+     * @param string $key
+     * @param string $placeholder
+     * @return string
+     */
+    public function getWithPlaceholder($key, $placeholder)
+    {
+        $text = $this->get($key);
+
+        if ($key === self::REGISTRATION_MISSING_FIELD) {
+            # we support field placeholders in here
+            $text = str_replace('%field%', $placeholder, $text);
+        }
+
+        return (string)$text;
+    }
+
+}

--- a/Resources/services/components/applepay_direct.xml
+++ b/Resources/services/components/applepay_direct.xml
@@ -17,6 +17,7 @@
         <service id="mollie_shopware.components.apple_pay_direct.services.button_builder"
                  class="MollieShopware\Components\ApplePayDirect\Services\ApplePayButtonBuilder" public="true">
             <argument type="service" id="mollie_shopware.config"/>
+            <argument type="service" id="config"/>
             <argument type="service" id="mollie_shopware.components.apple_pay_direct.services.payment_method"/>
             <argument type="service" id="mollie_shopware.components.apple_pay_direct.services.display_option"/>
         </service>

--- a/Resources/services/components/mixed.xml
+++ b/Resources/services/components/mixed.xml
@@ -180,5 +180,9 @@
             <argument type="service" id="dbal_connection"/>
         </service>
 
+        <service id="mollie_shopware.components.translation.frontend" class="MollieShopware\Components\Translation\FrontendTranslation" public="true">
+            <argument type="service" id="snippets"/>
+        </service>
+
     </services>
 </container>

--- a/Resources/snippets/frontend/mollie/plugins.ini
+++ b/Resources/snippets/frontend/mollie/plugins.ini
@@ -18,6 +18,7 @@ CardVerificationCodeLabel="CVC/CVV"
 CardExpiryDateLabel="Expiry date"
 CreditCardTagLine="Payment secured and provided by"
 BlockedDueRiskManagement="This payment method is unfortunately not available for your cart. You can select a different payment method and continue with your checkout."
+GuestAccountRegistrationMissingField="The provided buyer information does not contain enough data. Missing data: %field%"
 
 [de_DE]
 PaymentFailed="Zahlung fehlgeschlagen"
@@ -39,6 +40,8 @@ CardVerificationCodeLabel="CVV"
 CardExpiryDateLabel="MM/JJ"
 CreditCardTagLine="Zahlung gesichert und bereitgestellt von"
 BlockedDueRiskManagement="Diese Zahlungsart ist leider für diesen Kauf nicht verfügbar. Sie können eine andere Zahlungsart wählen und Ihren Einkauf fortführen."
+GuestAccountRegistrationMissingField="Die Käufer Informationen enthalten nicht genügend Daten. Fehlende Daten: %field%"
+
 
 [nl_NL]
 PaymentFailed="Betaling mislukt"
@@ -60,6 +63,8 @@ CardVerificationCodeLabel="CVV"
 CardExpiryDateLabel="MM/JJ"
 CreditCardTagLine="Betaling beveiligd en geleverd door"
 BlockedDueRiskManagement="Sorry, deze betaalmethode is niet beschikbaar voor deze aankoop. U kunt een andere betaalmethode kiezen en verder winkelen."
+GuestAccountRegistrationMissingField="De verstrekte kopersinformatie bevat niet voldoende gegevens. Ontbrekende gegevens: %field%"
+
 
 [fr_FR]
 PaymentFailed="Le paiement a échoué"
@@ -81,6 +86,8 @@ CardVerificationCodeLabel="CVV"
 CardExpiryDateLabel="MM/AA"
 CreditCardTagLine="Paiement sécurisé et émit par"
 BlockedDueRiskManagement="Cette méthode de paiement n’est malheureusement pas disponible pour votre panier. Vous pouvez sélectionner une méthode de paiement différente et continuer le processus de paiement."
+GuestAccountRegistrationMissingField="Les informations fournies sur l'acheteur ne contiennent pas suffisamment de données. Données manquantes: %field%"
+
 
 [es_ES]
 PaymentFailed="Pago fallido"
@@ -102,6 +109,8 @@ CardExpiryDateLabel="Fecha de caducidad"
 CardVerificationCodeLabel="CVC"
 CreditCardTagLine="Pago asegurado y proporcionado por"
 BlockedDueRiskManagement="Desafortunadamente, este método de pago no está disponible para su carrito. Puede seleccionar otro método de pago y continuar con su pago"
+GuestAccountRegistrationMissingField="La información del comprador proporcionada no contiene suficientes datos. Datos perdidos: %field%"
+
 
 [it_IT]
 PaymentFailed="Pagamento non riuscito"
@@ -126,3 +135,4 @@ CardExpiryDateLabel="Data scadenza"
 CardVerificationCodeLabel="CVC"
 CreditCardTagLine="Pagamento garantito e fornito da"
 BlockedDueRiskManagement="Questo metodo di pagamento non è purtroppo disponibile per la tua carta. Puoi selezionare un metodo diverso e proseguire per il checkout."
+GuestAccountRegistrationMissingField="Le informazioni sull'acquirente fornite non contengono dati sufficienti. Dati mancanti: %field%"

--- a/Resources/views/frontend/detail/index.tpl
+++ b/Resources/views/frontend/detail/index.tpl
@@ -1,0 +1,16 @@
+{extends file="parent:frontend/detail/index.tpl"}
+
+{block name='frontend_index_content'}
+    {if $sMollieErrorMessage}
+        <div class="alert is--error is--rounded" style="margin: 20px 0 20px 0;">
+            <div class="alert--icon">
+                <i class="icon--element icon--cross"></i>
+            </div>
+            <div class="alert--content">
+                {s name="YourPaymentHasFailed" namespace="frontend/mollie/plugins"}Your payment has failed. Please try again.{/s}<br />
+                {$sMollieErrorMessage}
+            </div>
+        </div>
+    {/if}
+    {$smarty.block.parent}
+{/block}

--- a/Resources/views/frontend/plugins/payment/mollie_applepay_direct.tpl
+++ b/Resources/views/frontend/plugins/payment/mollie_applepay_direct.tpl
@@ -10,6 +10,7 @@
    data-amount="{$sMollieApplePayDirectButton.amount}"
    data-country="{$sMollieApplePayDirectButton.country}"
    data-currency="{$sMollieApplePayDirectButton.currency}"
+   data-requirephone="{$sMollieApplePayDirectButton.requirements.phone}"
         {if $sMollieApplePayDirectButton.itemMode}
             data-addproducturl="{url module=frontend controller="MollieApplePayDirect" action="addProduct" forceSecure}"
             data-productnumber="{$sMollieApplePayDirectButton.addNumber}"

--- a/Subscriber/FrontendViewSubscriber.php
+++ b/Subscriber/FrontendViewSubscriber.php
@@ -18,6 +18,7 @@ class FrontendViewSubscriber implements SubscriberInterface
             'Enlight_Controller_Action_PreDispatch' => 'addComponentsVariables',
             'Enlight_Controller_Action_PreDispatch_Frontend' => 'addViewDirectory',
             'Enlight_Controller_Action_PreDispatch_Frontend_Checkout' => 'getController',
+            'Enlight_Controller_Action_PreDispatch_Frontend_Detail' => 'getController',
             'Theme_Compiler_Collect_Plugin_Javascript' => 'onCollectJavascript',
             'Theme_Compiler_Collect_Plugin_Less' => 'onCollectLess',
         ];
@@ -113,6 +114,15 @@ class FrontendViewSubscriber implements SubscriberInterface
             $session->mollieStatusError = null;
             $session->mollieError = null;
         }
+
+        # assigned already translated texts to the view
+        if ($session !== null && $view !== null && $session->offsetGet('mollieErrorMessage')) {
+            // assign errors to view
+            $view->assign('sMollieErrorMessage', $session->offsetGet('mollieErrorMessage'));
+            // unset error, so it won't show up on next page view
+            $session->mollieErrorMessage = null;
+        }
+
     }
 
     /**

--- a/Tests/PHPUnit/Components/ApplePayDirect/Models/Button/ApplePayButtonTest.php
+++ b/Tests/PHPUnit/Components/ApplePayDirect/Models/Button/ApplePayButtonTest.php
@@ -14,7 +14,7 @@ class ApplePayButtonTest extends TestCase
      */
     public function testItemModeOff()
     {
-        $button = new ApplePayButton(true, 'NL', 'EUR');
+        $button = new ApplePayButton(true, 'NL', 'EUR', false);
 
         $this->assertEquals(false, $button->isItemMode());
     }
@@ -25,7 +25,7 @@ class ApplePayButtonTest extends TestCase
      */
     public function testItemModeOn()
     {
-        $button = new ApplePayButton(true, 'NL', 'EUR');
+        $button = new ApplePayButton(true, 'NL', 'EUR', false);
         $button->setItemMode('ABC');
 
         $this->assertEquals(true, $button->isItemMode());
@@ -39,7 +39,7 @@ class ApplePayButtonTest extends TestCase
      */
     public function testFormatButton()
     {
-        $button = new ApplePayButton(true, 'NL', 'EUR');
+        $button = new ApplePayButton(true, 'NL', 'EUR', false);
         $button->setItemMode('ABC');
 
         $expected = [
@@ -49,8 +49,23 @@ class ApplePayButtonTest extends TestCase
             'itemMode' => true,
             'addNumber' => 'ABC',
             'displayOptions' => [],
+            'requirements' => [
+                'phone' => false,
+            ],
         ];
 
         $this->assertEquals($expected, $button->toArray());
     }
+
+    /**
+     * This test verifies that we also ask for the
+     * phone number if required
+     */
+    public function testPhoneNumberRequired()
+    {
+        $button = new ApplePayButton(true, 'NL', 'EUR', true);
+
+        $this->assertEquals(true, $button->toArray()['requirements']['phone']);
+    }
+
 }

--- a/Traits/Controllers/RedirectTrait.php
+++ b/Traits/Controllers/RedirectTrait.php
@@ -61,6 +61,25 @@ trait RedirectTrait
 
     /**
      * @param \Enlight_Controller_Action $controller
+     * @param int $articleID
+     * @param string $errorMessage
+     * @throws \Exception
+     */
+    protected function redirectToPDPWithError(\Enlight_Controller_Action $controller, $articleID, $errorMessage)
+    {
+        Shopware()->Session()->offsetSet('mollieErrorMessage', $errorMessage);
+
+        $url = $controller->Front()->Router()->assemble([
+            'controller' => 'detail',
+            'action' => 'index',
+            'sArticle' => $articleID,
+        ]);
+
+        $controller->redirect($url);
+    }
+
+    /**
+     * @param \Enlight_Controller_Action $controller
      * @param $uniqueId
      * @throws \Exception
      */

--- a/makefile
+++ b/makefile
@@ -68,7 +68,7 @@ pr: ## Prepares everything for a Pull Request
 	@php vendor/bin/php-cs-fixer fix --config=./.php_cs.php
 	@make phpcheck -B
 	@make phpmin -B
-	@make test -B
+	@make phpunit -B
 	@make stan -B
 	@make jest -B
 	@make eslint -B


### PR DESCRIPTION
this pull request makes sure to also require a phone number in apple pay direct, if configured in the shop.

the shop configuration will be passed on to apple pay, which will then add that requirement in javascript.
the data is then added in the post variables.

the php action will then also add the phone number to the registration.

the error handling has been improved in case something (or other keys) are not passed on.
violation exceptions now lead to a custom RegistrationInvalidField exception with more data about that field.

errors like these will then be shown on the PDP, because registration was not complete, means that the user cannot be forwarded to the cart to finish the checkout.
to show these errors on the PDP, an existing subscriber had to be modified to allow that, as well as a new smarty view to show custom errors on PDP.
instead of just using snippets in the frontend, i moved over to translate in PHP, which allows use to add that field to the template message. its also easier than the other approach