### PR TITLE
MOL-896 fatal error on credit card service

### DIFF
--- a/Components/Services/CreditCardService.php
+++ b/Components/Services/CreditCardService.php
@@ -68,7 +68,7 @@ class CreditCardService
 
     public function getCardToken()
     {
-        /** @var Customer|null $customer */
+        /** @var null|Customer $customer */
         $customer = $this->customer->getCurrent();
 
         if ($customer === null) {

--- a/Components/Services/CreditCardService.php
+++ b/Components/Services/CreditCardService.php
@@ -4,6 +4,7 @@ namespace MollieShopware\Components\Services;
 
 use Mollie\Api\MollieApiClient;
 use MollieShopware\Components\CurrentCustomer;
+use MollieShopware\Exceptions\CustomerNotFoundException;
 use Shopware\Components\Model\ModelManager;
 use Shopware\Models\Attribute\Customer as CustomerAttribute;
 use Shopware\Models\Customer\Customer;
@@ -67,18 +68,20 @@ class CreditCardService
 
     public function getCardToken()
     {
-        $customerAttributes = null;
-
-        /** @var Customer $customer */
+        /** @var Customer|null $customer */
         $customer = $this->customer->getCurrent();
 
-        if ($customer !== null) {
-            $customerAttributes = $customer->getAttribute();
+        if ($customer === null) {
+            throw new CustomerNotFoundException(
+                'The current customer could not be found.'
+            );
         }
 
-        if ($customerAttributes !== null &&
-            method_exists($customerAttributes, 'getMollieShopwareCreditCardToken')) {
-            return $customerAttributes->getMollieShopwareCreditCardToken();
+        if (
+            $customer->getAttribute() !== null &&
+            method_exists($customer->getAttribute(), 'getMollieShopwareCreditCardToken')
+        ) {
+            return $customer->getAttribute()->getMollieShopwareCreditCardToken();
         }
 
         /**

--- a/Exceptions/CustomerNotFoundException.php
+++ b/Exceptions/CustomerNotFoundException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace MollieShopware\Exceptions;
+
+class CustomerNotFoundException extends \Exception
+{
+    /**
+     * CustomerNotFoundException constructor.
+     * @param string $message
+     *
+     */
+    public function __construct($message)
+    {
+        parent::__construct($message);
+    }
+}

--- a/Facades/CheckoutSession/CheckoutSessionFacade.php
+++ b/Facades/CheckoutSession/CheckoutSessionFacade.php
@@ -17,6 +17,7 @@ use MollieShopware\Components\SessionManager\SessionManager;
 use MollieShopware\Components\Shipping\Shipping;
 use MollieShopware\Components\Shipping\ShippingInterface;
 use MollieShopware\Components\TransactionBuilder\TransactionBuilder;
+use MollieShopware\Exceptions\CustomerNotFoundException;
 use MollieShopware\Models\Transaction;
 use MollieShopware\Models\TransactionRepository;
 use MollieShopware\Services\TokenAnonymizer\TokenAnonymizer;
@@ -199,7 +200,15 @@ class CheckoutSessionFacade
 
         # we want to log anonymized tokens
         # to see if they are used correctly.
-        $tokenCreditCard = $this->creditCardService->getCardToken();
+        try {
+            $tokenCreditCard = $this->creditCardService->getCardToken();
+        } catch (\Exception $exception) {
+            # prevent the checkout from failing, because at this
+            # point it's not sure if we need the credit card
+            # token to finish the payment at Mollie
+            $tokenCreditCard = '';
+        }
+
         $tokenApplePay = $this->applePay->getPaymentToken();
 
 

--- a/Resources/services/components/mixed.xml
+++ b/Resources/services/components/mixed.xml
@@ -49,6 +49,7 @@
             <argument type="service" id="mollie_shopware.config"/>
             <argument type="service" id="mollie_shopware.components.config.payments"/>
             <argument type="service" id="mollie_shopware.gateways.mollie"/>
+            <argument type="service" id="mollie_shopware.components.logger"/>
             <argument>%shopware.custom%</argument>
         </service>
 


### PR DESCRIPTION
I added extra logging around retrieving the credit card payment token. There's an exception in the `CreditCardService` now that, when thrown, is catched in a try/catch block.

I believe the method could throw an exception, and thereby the checkout would fail, even if the token isn't required to finish the payment. To prevent that from happening, I catch the exception thrown by the `getCardToken` method (in `Components/Services/CreditCardService.php`) and log it.